### PR TITLE
feat: contract call offchain data

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,6 @@
+[test-groups]
+rest-service-same-port = { max-threads = 1 }
+
+[[profile.default.overrides]]
+filter = 'package(rest-service)'
+test-group = 'rest-service-same-port'

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ target/
 *.key
 config.toml
 store
+storage

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4678,6 +4678,7 @@ dependencies = [
  "reqwest 0.12.9",
  "serde",
  "serde_json",
+ "serial_test",
  "solana-client",
  "solana-listener",
  "solana-sdk",
@@ -5032,6 +5033,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
+name = "scc"
+version = "2.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b202022bb57c049555430e11fc22fea12909276a80a4c3d368da36ac1d88ed"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5081,6 +5091,12 @@ dependencies = [
  "ring 0.17.8",
  "untrusted 0.9.0",
 ]
+
+[[package]]
+name = "sdd"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49c1eeaf4b6a87c7479688c6d52b9f1153cedd3c489300564f932b065c6eab95"
 
 [[package]]
 name = "seahash"
@@ -5277,6 +5293,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d846214a9854ef724f3da161b426242d8de7c1fc7de2f89bb1efcb154dca79d"
 dependencies = [
  "darling",
+ "proc-macro2 1.0.92",
+ "quote 1.0.37",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b258109f244e1d6891bf1053a55d63a5cd4f8f4c30cf9a1280989f80e7a1fa9"
+dependencies = [
+ "futures",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
+dependencies = [
  "proc-macro2 1.0.92",
  "quote 1.0.37",
  "syn 2.0.90",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -656,11 +656,11 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 [[package]]
 name = "axelar-executable"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/solana-axelar.git?rev=91c8cf2#91c8cf2aa0702d6bbaff21164d79f8640815fb53"
+source = "git+https://github.com/eigerco/solana-axelar.git?rev=e212e33#e212e33de8a877e46bd5d0d74bed7597dbf3e76d"
 dependencies = [
  "alloy-sol-types",
- "axelar-solana-encoding 0.1.0 (git+https://github.com/eigerco/solana-axelar.git?rev=91c8cf2)",
- "axelar-solana-gateway 0.1.0 (git+https://github.com/eigerco/solana-axelar.git?rev=91c8cf2)",
+ "axelar-solana-encoding",
+ "axelar-solana-gateway",
  "borsh 1.5.3",
  "num-derive",
  "num-traits",
@@ -672,9 +672,9 @@ dependencies = [
 [[package]]
 name = "axelar-executable-old"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/solana-axelar.git?rev=91c8cf2#91c8cf2aa0702d6bbaff21164d79f8640815fb53"
+source = "git+https://github.com/eigerco/solana-axelar.git?rev=e212e33#e212e33de8a877e46bd5d0d74bed7597dbf3e76d"
 dependencies = [
- "axelar-message-primitives 0.1.0 (git+https://github.com/eigerco/solana-axelar.git?rev=91c8cf2)",
+ "axelar-message-primitives",
  "axelar-rkyv-encoding",
  "borsh 1.5.3",
  "gmp-gateway",
@@ -684,23 +684,7 @@ dependencies = [
 [[package]]
 name = "axelar-message-primitives"
 version = "0.1.0"
-source = "git+ssh://git@github.com/eigerco/solana-axelar-internal.git?branch=feat%2Fgtw-large-outgoing-messages#d8691a2b3813693f82a99a092ce1301c62d833c7"
-dependencies = [
- "alloy-primitives",
- "alloy-sol-types",
- "bnum 0.10.0",
- "borsh 1.5.3",
- "bytemuck",
- "hex",
- "rkyv",
- "solana-program",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "axelar-message-primitives"
-version = "0.1.0"
-source = "git+https://github.com/eigerco/solana-axelar.git?rev=91c8cf2#91c8cf2aa0702d6bbaff21164d79f8640815fb53"
+source = "git+https://github.com/eigerco/solana-axelar.git?rev=e212e33#e212e33de8a877e46bd5d0d74bed7597dbf3e76d"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -716,7 +700,7 @@ dependencies = [
 [[package]]
 name = "axelar-rkyv-encoding"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/solana-axelar.git?rev=91c8cf2#91c8cf2aa0702d6bbaff21164d79f8640815fb53"
+source = "git+https://github.com/eigerco/solana-axelar.git?rev=e212e33#e212e33de8a877e46bd5d0d74bed7597dbf3e76d"
 dependencies = [
  "arrayref",
  "bitflags 2.6.0",
@@ -736,24 +720,7 @@ dependencies = [
 [[package]]
 name = "axelar-solana-encoding"
 version = "0.1.0"
-source = "git+ssh://git@github.com/eigerco/solana-axelar-internal.git?branch=feat%2Fgtw-large-outgoing-messages#d8691a2b3813693f82a99a092ce1301c62d833c7"
-dependencies = [
- "arrayref",
- "borsh 1.5.3",
- "bs58",
- "hex",
- "rkyv",
- "rs_merkle",
- "sha3 0.10.8",
- "solana-program",
- "thiserror 1.0.69",
- "udigest",
-]
-
-[[package]]
-name = "axelar-solana-encoding"
-version = "0.1.0"
-source = "git+https://github.com/eigerco/solana-axelar.git?rev=91c8cf2#91c8cf2aa0702d6bbaff21164d79f8640815fb53"
+source = "git+https://github.com/eigerco/solana-axelar.git?rev=e212e33#e212e33de8a877e46bd5d0d74bed7597dbf3e76d"
 dependencies = [
  "arrayref",
  "borsh 1.5.3",
@@ -770,10 +737,10 @@ dependencies = [
 [[package]]
 name = "axelar-solana-gateway"
 version = "0.1.0"
-source = "git+ssh://git@github.com/eigerco/solana-axelar-internal.git?branch=feat%2Fgtw-large-outgoing-messages#d8691a2b3813693f82a99a092ce1301c62d833c7"
+source = "git+https://github.com/eigerco/solana-axelar.git?rev=e212e33#e212e33de8a877e46bd5d0d74bed7597dbf3e76d"
 dependencies = [
- "axelar-message-primitives 0.1.0 (git+ssh://git@github.com/eigerco/solana-axelar-internal.git?branch=feat%2Fgtw-large-outgoing-messages)",
- "axelar-solana-encoding 0.1.0 (git+ssh://git@github.com/eigerco/solana-axelar-internal.git?branch=feat%2Fgtw-large-outgoing-messages)",
+ "axelar-message-primitives",
+ "axelar-solana-encoding",
  "bincode",
  "bitvec",
  "borsh 1.5.3",
@@ -784,29 +751,7 @@ dependencies = [
  "libsecp256k1",
  "num-derive",
  "num-traits",
- "program-utils 0.1.0 (git+ssh://git@github.com/eigerco/solana-axelar-internal.git?branch=feat%2Fgtw-large-outgoing-messages)",
- "solana-program",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "axelar-solana-gateway"
-version = "0.1.0"
-source = "git+https://github.com/eigerco/solana-axelar.git?rev=91c8cf2#91c8cf2aa0702d6bbaff21164d79f8640815fb53"
-dependencies = [
- "axelar-message-primitives 0.1.0 (git+https://github.com/eigerco/solana-axelar.git?rev=91c8cf2)",
- "axelar-solana-encoding 0.1.0 (git+https://github.com/eigerco/solana-axelar.git?rev=91c8cf2)",
- "bincode",
- "bitvec",
- "borsh 1.5.3",
- "bytemuck",
- "ed25519-dalek 2.1.1",
- "hex",
- "itertools 0.12.1",
- "libsecp256k1",
- "num-derive",
- "num-traits",
- "program-utils 0.1.0 (git+https://github.com/eigerco/solana-axelar.git?rev=91c8cf2)",
+ "program-utils",
  "solana-program",
  "thiserror 1.0.69",
 ]
@@ -814,7 +759,7 @@ dependencies = [
 [[package]]
 name = "axelar-solana-governance"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/solana-axelar.git?rev=91c8cf2#91c8cf2aa0702d6bbaff21164d79f8640815fb53"
+source = "git+https://github.com/eigerco/solana-axelar.git?rev=e212e33#e212e33de8a877e46bd5d0d74bed7597dbf3e76d"
 dependencies = [
  "alloy-sol-types",
  "axelar-executable-old",
@@ -822,7 +767,7 @@ dependencies = [
  "base64 0.21.7",
  "gmp-gateway",
  "governance-gmp",
- "program-utils 0.1.0 (git+https://github.com/eigerco/solana-axelar.git?rev=91c8cf2)",
+ "program-utils",
  "rkyv",
  "solana-program",
 ]
@@ -830,19 +775,19 @@ dependencies = [
 [[package]]
 name = "axelar-solana-its"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/solana-axelar.git?rev=91c8cf2#91c8cf2aa0702d6bbaff21164d79f8640815fb53"
+source = "git+https://github.com/eigerco/solana-axelar.git?rev=e212e33#e212e33de8a877e46bd5d0d74bed7597dbf3e76d"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
  "axelar-executable",
- "axelar-message-primitives 0.1.0 (git+https://github.com/eigerco/solana-axelar.git?rev=91c8cf2)",
+ "axelar-message-primitives",
  "axelar-rkyv-encoding",
- "axelar-solana-encoding 0.1.0 (git+https://github.com/eigerco/solana-axelar.git?rev=91c8cf2)",
- "axelar-solana-gateway 0.1.0 (git+https://github.com/eigerco/solana-axelar.git?rev=91c8cf2)",
+ "axelar-solana-encoding",
+ "axelar-solana-gateway",
  "bitflags 2.6.0",
  "borsh 1.5.3",
  "interchain-token-transfer-gmp",
- "program-utils 0.1.0 (git+https://github.com/eigerco/solana-axelar.git?rev=91c8cf2)",
+ "program-utils",
  "rkyv",
  "role-management",
  "solana-program",
@@ -2363,20 +2308,9 @@ dependencies = [
 [[package]]
 name = "gateway-event-stack"
 version = "0.1.0"
-source = "git+ssh://git@github.com/eigerco/solana-axelar-internal.git?branch=feat%2Fgtw-large-outgoing-messages#d8691a2b3813693f82a99a092ce1301c62d833c7"
+source = "git+https://github.com/eigerco/solana-axelar.git?rev=e212e33#e212e33de8a877e46bd5d0d74bed7597dbf3e76d"
 dependencies = [
- "axelar-solana-gateway 0.1.0 (git+ssh://git@github.com/eigerco/solana-axelar-internal.git?branch=feat%2Fgtw-large-outgoing-messages)",
- "base64 0.21.7",
- "solana-sdk",
- "tracing",
-]
-
-[[package]]
-name = "gateway-event-stack"
-version = "0.1.0"
-source = "git+https://github.com/eigerco/solana-axelar.git?rev=91c8cf2#91c8cf2aa0702d6bbaff21164d79f8640815fb53"
-dependencies = [
- "axelar-solana-gateway 0.1.0 (git+https://github.com/eigerco/solana-axelar.git?rev=91c8cf2)",
+ "axelar-solana-gateway",
  "base64 0.21.7",
  "solana-sdk",
  "tracing",
@@ -2458,10 +2392,10 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 [[package]]
 name = "gmp-gateway"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/solana-axelar.git?rev=91c8cf2#91c8cf2aa0702d6bbaff21164d79f8640815fb53"
+source = "git+https://github.com/eigerco/solana-axelar.git?rev=e212e33#e212e33de8a877e46bd5d0d74bed7597dbf3e76d"
 dependencies = [
  "arrayref",
- "axelar-message-primitives 0.1.0 (git+https://github.com/eigerco/solana-axelar.git?rev=91c8cf2)",
+ "axelar-message-primitives",
  "axelar-rkyv-encoding",
  "base64 0.21.7",
  "bincode",
@@ -2473,7 +2407,7 @@ dependencies = [
  "libsecp256k1",
  "num-derive",
  "num-traits",
- "program-utils 0.1.0 (git+https://github.com/eigerco/solana-axelar.git?rev=91c8cf2)",
+ "program-utils",
  "rkyv",
  "solana-program",
  "thiserror 1.0.69",
@@ -2493,7 +2427,7 @@ dependencies = [
 [[package]]
 name = "governance-gmp"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/solana-axelar.git?rev=91c8cf2#91c8cf2aa0702d6bbaff21164d79f8640815fb53"
+source = "git+https://github.com/eigerco/solana-axelar.git?rev=e212e33#e212e33de8a877e46bd5d0d74bed7597dbf3e76d"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -3110,7 +3044,7 @@ dependencies = [
 [[package]]
 name = "interchain-token-transfer-gmp"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/solana-axelar.git?rev=91c8cf2#91c8cf2aa0702d6bbaff21164d79f8640815fb53"
+source = "git+https://github.com/eigerco/solana-axelar.git?rev=e212e33#e212e33de8a877e46bd5d0d74bed7597dbf3e76d"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -4158,17 +4092,7 @@ dependencies = [
 [[package]]
 name = "program-utils"
 version = "0.1.0"
-source = "git+ssh://git@github.com/eigerco/solana-axelar-internal.git?branch=feat%2Fgtw-large-outgoing-messages#d8691a2b3813693f82a99a092ce1301c62d833c7"
-dependencies = [
- "borsh 1.5.3",
- "rkyv",
- "solana-program",
-]
-
-[[package]]
-name = "program-utils"
-version = "0.1.0"
-source = "git+https://github.com/eigerco/solana-axelar.git?rev=91c8cf2#91c8cf2aa0702d6bbaff21164d79f8640815fb53"
+source = "git+https://github.com/eigerco/solana-axelar.git?rev=e212e33#e212e33de8a877e46bd5d0d74bed7597dbf3e76d"
 dependencies = [
  "borsh 1.5.3",
  "rkyv",
@@ -4743,11 +4667,11 @@ name = "rest-service"
 version = "0.1.0"
 dependencies = [
  "amplifier-api",
- "axelar-solana-gateway 0.1.0 (git+ssh://git@github.com/eigerco/solana-axelar-internal.git?branch=feat%2Fgtw-large-outgoing-messages)",
+ "axelar-solana-gateway",
  "axum",
  "eyre",
  "futures",
- "gateway-event-stack 0.1.0 (git+ssh://git@github.com/eigerco/solana-axelar-internal.git?branch=feat%2Fgtw-large-outgoing-messages)",
+ "gateway-event-stack",
  "indoc",
  "relayer-amplifier-api-integration",
  "relayer-engine",
@@ -4762,7 +4686,6 @@ dependencies = [
  "tokio",
  "tower-http",
  "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -4865,12 +4788,12 @@ dependencies = [
 [[package]]
 name = "role-management"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/solana-axelar.git?rev=91c8cf2#91c8cf2aa0702d6bbaff21164d79f8640815fb53"
+source = "git+https://github.com/eigerco/solana-axelar.git?rev=e212e33#e212e33de8a877e46bd5d0d74bed7597dbf3e76d"
 dependencies = [
  "bincode",
  "bitflags 2.6.0",
  "borsh 1.5.3",
- "program-utils 0.1.0 (git+https://github.com/eigerco/solana-axelar.git?rev=91c8cf2)",
+ "program-utils",
  "solana-program",
 ]
 
@@ -5692,12 +5615,12 @@ dependencies = [
 name = "solana-event-forwarder"
 version = "0.1.0"
 dependencies = [
- "axelar-solana-gateway 0.1.0 (git+https://github.com/eigerco/solana-axelar.git?rev=91c8cf2)",
+ "axelar-solana-gateway",
  "base64 0.22.1",
  "bs58",
  "eyre",
  "futures",
- "gateway-event-stack 0.1.0 (git+https://github.com/eigerco/solana-axelar.git?rev=91c8cf2)",
+ "gateway-event-stack",
  "pretty_assertions",
  "relayer-amplifier-api-integration",
  "relayer-engine",
@@ -5714,8 +5637,8 @@ dependencies = [
  "amplifier-api",
  "async-trait",
  "axelar-executable",
- "axelar-solana-encoding 0.1.0 (git+https://github.com/eigerco/solana-axelar.git?rev=91c8cf2)",
- "axelar-solana-gateway 0.1.0 (git+https://github.com/eigerco/solana-axelar.git?rev=91c8cf2)",
+ "axelar-solana-encoding",
+ "axelar-solana-gateway",
  "axelar-solana-governance",
  "axelar-solana-its",
  "bs58",
@@ -5752,7 +5675,7 @@ dependencies = [
 name = "solana-listener"
 version = "0.1.0"
 dependencies = [
- "axelar-solana-gateway 0.1.0 (git+https://github.com/eigerco/solana-axelar.git?rev=91c8cf2)",
+ "axelar-solana-gateway",
  "chrono",
  "common-serde-utils 0.1.0",
  "common-serde-utils 0.1.0 (git+https://github.com/eigerco/axelar-relayer-core.git?branch=main)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -659,8 +659,8 @@ version = "0.1.0"
 source = "git+https://github.com/eigerco/solana-axelar.git?rev=91c8cf2#91c8cf2aa0702d6bbaff21164d79f8640815fb53"
 dependencies = [
  "alloy-sol-types",
- "axelar-solana-encoding",
- "axelar-solana-gateway",
+ "axelar-solana-encoding 0.1.0 (git+https://github.com/eigerco/solana-axelar.git?rev=91c8cf2)",
+ "axelar-solana-gateway 0.1.0 (git+https://github.com/eigerco/solana-axelar.git?rev=91c8cf2)",
  "borsh 1.5.3",
  "num-derive",
  "num-traits",
@@ -674,11 +674,27 @@ name = "axelar-executable-old"
 version = "0.1.0"
 source = "git+https://github.com/eigerco/solana-axelar.git?rev=91c8cf2#91c8cf2aa0702d6bbaff21164d79f8640815fb53"
 dependencies = [
- "axelar-message-primitives",
+ "axelar-message-primitives 0.1.0 (git+https://github.com/eigerco/solana-axelar.git?rev=91c8cf2)",
  "axelar-rkyv-encoding",
  "borsh 1.5.3",
  "gmp-gateway",
  "solana-program",
+]
+
+[[package]]
+name = "axelar-message-primitives"
+version = "0.1.0"
+source = "git+ssh://git@github.com/eigerco/solana-axelar-internal.git?branch=feat%2Fgtw-large-outgoing-messages#d8691a2b3813693f82a99a092ce1301c62d833c7"
+dependencies = [
+ "alloy-primitives",
+ "alloy-sol-types",
+ "bnum 0.10.0",
+ "borsh 1.5.3",
+ "bytemuck",
+ "hex",
+ "rkyv",
+ "solana-program",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -720,6 +736,23 @@ dependencies = [
 [[package]]
 name = "axelar-solana-encoding"
 version = "0.1.0"
+source = "git+ssh://git@github.com/eigerco/solana-axelar-internal.git?branch=feat%2Fgtw-large-outgoing-messages#d8691a2b3813693f82a99a092ce1301c62d833c7"
+dependencies = [
+ "arrayref",
+ "borsh 1.5.3",
+ "bs58",
+ "hex",
+ "rkyv",
+ "rs_merkle",
+ "sha3 0.10.8",
+ "solana-program",
+ "thiserror 1.0.69",
+ "udigest",
+]
+
+[[package]]
+name = "axelar-solana-encoding"
+version = "0.1.0"
 source = "git+https://github.com/eigerco/solana-axelar.git?rev=91c8cf2#91c8cf2aa0702d6bbaff21164d79f8640815fb53"
 dependencies = [
  "arrayref",
@@ -737,10 +770,10 @@ dependencies = [
 [[package]]
 name = "axelar-solana-gateway"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/solana-axelar.git?rev=91c8cf2#91c8cf2aa0702d6bbaff21164d79f8640815fb53"
+source = "git+ssh://git@github.com/eigerco/solana-axelar-internal.git?branch=feat%2Fgtw-large-outgoing-messages#d8691a2b3813693f82a99a092ce1301c62d833c7"
 dependencies = [
- "axelar-message-primitives",
- "axelar-solana-encoding",
+ "axelar-message-primitives 0.1.0 (git+ssh://git@github.com/eigerco/solana-axelar-internal.git?branch=feat%2Fgtw-large-outgoing-messages)",
+ "axelar-solana-encoding 0.1.0 (git+ssh://git@github.com/eigerco/solana-axelar-internal.git?branch=feat%2Fgtw-large-outgoing-messages)",
  "bincode",
  "bitvec",
  "borsh 1.5.3",
@@ -751,7 +784,29 @@ dependencies = [
  "libsecp256k1",
  "num-derive",
  "num-traits",
- "program-utils",
+ "program-utils 0.1.0 (git+ssh://git@github.com/eigerco/solana-axelar-internal.git?branch=feat%2Fgtw-large-outgoing-messages)",
+ "solana-program",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "axelar-solana-gateway"
+version = "0.1.0"
+source = "git+https://github.com/eigerco/solana-axelar.git?rev=91c8cf2#91c8cf2aa0702d6bbaff21164d79f8640815fb53"
+dependencies = [
+ "axelar-message-primitives 0.1.0 (git+https://github.com/eigerco/solana-axelar.git?rev=91c8cf2)",
+ "axelar-solana-encoding 0.1.0 (git+https://github.com/eigerco/solana-axelar.git?rev=91c8cf2)",
+ "bincode",
+ "bitvec",
+ "borsh 1.5.3",
+ "bytemuck",
+ "ed25519-dalek 2.1.1",
+ "hex",
+ "itertools 0.12.1",
+ "libsecp256k1",
+ "num-derive",
+ "num-traits",
+ "program-utils 0.1.0 (git+https://github.com/eigerco/solana-axelar.git?rev=91c8cf2)",
  "solana-program",
  "thiserror 1.0.69",
 ]
@@ -767,7 +822,7 @@ dependencies = [
  "base64 0.21.7",
  "gmp-gateway",
  "governance-gmp",
- "program-utils",
+ "program-utils 0.1.0 (git+https://github.com/eigerco/solana-axelar.git?rev=91c8cf2)",
  "rkyv",
  "solana-program",
 ]
@@ -780,14 +835,14 @@ dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
  "axelar-executable",
- "axelar-message-primitives",
+ "axelar-message-primitives 0.1.0 (git+https://github.com/eigerco/solana-axelar.git?rev=91c8cf2)",
  "axelar-rkyv-encoding",
- "axelar-solana-encoding",
- "axelar-solana-gateway",
+ "axelar-solana-encoding 0.1.0 (git+https://github.com/eigerco/solana-axelar.git?rev=91c8cf2)",
+ "axelar-solana-gateway 0.1.0 (git+https://github.com/eigerco/solana-axelar.git?rev=91c8cf2)",
  "bitflags 2.6.0",
  "borsh 1.5.3",
  "interchain-token-transfer-gmp",
- "program-utils",
+ "program-utils 0.1.0 (git+https://github.com/eigerco/solana-axelar.git?rev=91c8cf2)",
  "rkyv",
  "role-management",
  "solana-program",
@@ -812,7 +867,7 @@ dependencies = [
  "http 1.2.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.5.0",
+ "hyper 1.5.1",
  "hyper-util",
  "itoa",
  "matchit",
@@ -827,7 +882,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper 1.0.2",
  "tokio",
- "tower 0.5.1",
+ "tower 0.5.2",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -2308,9 +2363,20 @@ dependencies = [
 [[package]]
 name = "gateway-event-stack"
 version = "0.1.0"
+source = "git+ssh://git@github.com/eigerco/solana-axelar-internal.git?branch=feat%2Fgtw-large-outgoing-messages#d8691a2b3813693f82a99a092ce1301c62d833c7"
+dependencies = [
+ "axelar-solana-gateway 0.1.0 (git+ssh://git@github.com/eigerco/solana-axelar-internal.git?branch=feat%2Fgtw-large-outgoing-messages)",
+ "base64 0.21.7",
+ "solana-sdk",
+ "tracing",
+]
+
+[[package]]
+name = "gateway-event-stack"
+version = "0.1.0"
 source = "git+https://github.com/eigerco/solana-axelar.git?rev=91c8cf2#91c8cf2aa0702d6bbaff21164d79f8640815fb53"
 dependencies = [
- "axelar-solana-gateway",
+ "axelar-solana-gateway 0.1.0 (git+https://github.com/eigerco/solana-axelar.git?rev=91c8cf2)",
  "base64 0.21.7",
  "solana-sdk",
  "tracing",
@@ -2395,7 +2461,7 @@ version = "0.1.0"
 source = "git+https://github.com/eigerco/solana-axelar.git?rev=91c8cf2#91c8cf2aa0702d6bbaff21164d79f8640815fb53"
 dependencies = [
  "arrayref",
- "axelar-message-primitives",
+ "axelar-message-primitives 0.1.0 (git+https://github.com/eigerco/solana-axelar.git?rev=91c8cf2)",
  "axelar-rkyv-encoding",
  "base64 0.21.7",
  "bincode",
@@ -2407,7 +2473,7 @@ dependencies = [
  "libsecp256k1",
  "num-derive",
  "num-traits",
- "program-utils",
+ "program-utils 0.1.0 (git+https://github.com/eigerco/solana-axelar.git?rev=91c8cf2)",
  "rkyv",
  "solana-program",
  "thiserror 1.0.69",
@@ -2748,7 +2814,7 @@ dependencies = [
  "http 1.2.0",
  "hyper 1.5.1",
  "hyper-util",
- "rustls 0.23.19",
+ "rustls 0.23.20",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.1",
@@ -4092,6 +4158,16 @@ dependencies = [
 [[package]]
 name = "program-utils"
 version = "0.1.0"
+source = "git+ssh://git@github.com/eigerco/solana-axelar-internal.git?branch=feat%2Fgtw-large-outgoing-messages#d8691a2b3813693f82a99a092ce1301c62d833c7"
+dependencies = [
+ "borsh 1.5.3",
+ "rkyv",
+ "solana-program",
+]
+
+[[package]]
+name = "program-utils"
+version = "0.1.0"
 source = "git+https://github.com/eigerco/solana-axelar.git?rev=91c8cf2#91c8cf2aa0702d6bbaff21164d79f8640815fb53"
 dependencies = [
  "borsh 1.5.3",
@@ -4220,7 +4296,7 @@ dependencies = [
  "quinn-proto 0.11.9",
  "quinn-udp 0.5.8",
  "rustc-hash 2.1.0",
- "rustls 0.23.19",
+ "rustls 0.23.20",
  "socket2",
  "thiserror 2.0.6",
  "tokio",
@@ -4256,7 +4332,7 @@ dependencies = [
  "rand 0.8.5",
  "ring 0.17.8",
  "rustc-hash 2.1.0",
- "rustls 0.23.19",
+ "rustls 0.23.20",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.6",
@@ -4436,9 +4512,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
+checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
 dependencies = [
  "bitflags 2.6.0",
 ]
@@ -4627,7 +4703,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn 0.11.6",
- "rustls 0.23.19",
+ "rustls 0.23.20",
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "serde",
@@ -4666,11 +4742,27 @@ dependencies = [
 name = "rest-service"
 version = "0.1.0"
 dependencies = [
+ "amplifier-api",
+ "axelar-solana-gateway 0.1.0 (git+ssh://git@github.com/eigerco/solana-axelar-internal.git?branch=feat%2Fgtw-large-outgoing-messages)",
  "axum",
  "eyre",
  "futures",
+ "gateway-event-stack 0.1.0 (git+ssh://git@github.com/eigerco/solana-axelar-internal.git?branch=feat%2Fgtw-large-outgoing-messages)",
+ "indoc",
+ "relayer-amplifier-api-integration",
  "relayer-engine",
+ "reqwest 0.12.9",
+ "serde",
+ "serde_json",
+ "solana-client",
+ "solana-listener",
+ "solana-sdk",
+ "test-log",
+ "thiserror 1.0.69",
  "tokio",
+ "tower-http",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -4778,7 +4870,7 @@ dependencies = [
  "bincode",
  "bitflags 2.6.0",
  "borsh 1.5.3",
- "program-utils",
+ "program-utils 0.1.0 (git+https://github.com/eigerco/solana-axelar.git?rev=91c8cf2)",
  "solana-program",
 ]
 
@@ -4920,9 +5012,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.19"
+version = "0.23.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "934b404430bb06b3fae2cba809eb45a1ab1aecd64491213d7c3301b88393f8d1"
+checksum = "5065c3f250cbd332cd894be57c40fa52387247659b14a2d6041d121547903b1b"
 dependencies = [
  "once_cell",
  "ring 0.17.8",
@@ -5475,6 +5567,7 @@ dependencies = [
  "pretty_assertions",
  "relayer-amplifier-api-integration",
  "relayer-engine",
+ "rest-service",
  "retrying-solana-http-sender",
  "serde",
  "solana-event-forwarder",
@@ -5599,12 +5692,12 @@ dependencies = [
 name = "solana-event-forwarder"
 version = "0.1.0"
 dependencies = [
- "axelar-solana-gateway",
+ "axelar-solana-gateway 0.1.0 (git+https://github.com/eigerco/solana-axelar.git?rev=91c8cf2)",
  "base64 0.22.1",
  "bs58",
  "eyre",
  "futures",
- "gateway-event-stack",
+ "gateway-event-stack 0.1.0 (git+https://github.com/eigerco/solana-axelar.git?rev=91c8cf2)",
  "pretty_assertions",
  "relayer-amplifier-api-integration",
  "relayer-engine",
@@ -5621,8 +5714,8 @@ dependencies = [
  "amplifier-api",
  "async-trait",
  "axelar-executable",
- "axelar-solana-encoding",
- "axelar-solana-gateway",
+ "axelar-solana-encoding 0.1.0 (git+https://github.com/eigerco/solana-axelar.git?rev=91c8cf2)",
+ "axelar-solana-gateway 0.1.0 (git+https://github.com/eigerco/solana-axelar.git?rev=91c8cf2)",
  "axelar-solana-governance",
  "axelar-solana-its",
  "bs58",
@@ -5659,7 +5752,7 @@ dependencies = [
 name = "solana-listener"
 version = "0.1.0"
 dependencies = [
- "axelar-solana-gateway",
+ "axelar-solana-gateway 0.1.0 (git+https://github.com/eigerco/solana-axelar.git?rev=91c8cf2)",
  "chrono",
  "common-serde-utils 0.1.0",
  "common-serde-utils 0.1.0 (git+https://github.com/eigerco/axelar-relayer-core.git?branch=main)",
@@ -7132,7 +7225,7 @@ version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37"
 dependencies = [
- "rustls 0.23.19",
+ "rustls 0.23.20",
  "tokio",
 ]
 
@@ -7270,15 +7363,31 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2873938d487c3cfb9aed7546dc9f2711d867c9f90c46b889989a2cb84eba6b4f"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "sync_wrapper 0.1.2",
+ "sync_wrapper 1.0.2",
  "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "403fa3b783d4b626a8ad51d766ab03cb6d2dbfc46b1c5d4448395e6628dc9697"
+dependencies = [
+ "bitflags 2.6.0",
+ "bytes",
+ "http 1.2.0",
+ "http-body 1.0.1",
+ "pin-project-lite",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -812,6 +812,8 @@ dependencies = [
  "http 1.2.0",
  "http-body 1.0.1",
  "http-body-util",
+ "hyper 1.5.0",
+ "hyper-util",
  "itoa",
  "matchit",
  "memchr",
@@ -820,10 +822,15 @@ dependencies = [
  "pin-project-lite",
  "rustversion",
  "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
  "sync_wrapper 1.0.2",
+ "tokio",
  "tower 0.5.1",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -844,6 +851,7 @@ dependencies = [
  "sync_wrapper 1.0.2",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -4655,6 +4663,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rest-service"
+version = "0.1.0"
+dependencies = [
+ "axum",
+ "eyre",
+ "futures",
+ "relayer-engine",
+ "tokio",
+]
+
+[[package]]
 name = "retrying-solana-http-sender"
 version = "0.1.0"
 dependencies = [
@@ -5162,6 +5181,16 @@ dependencies = [
  "itoa",
  "memchr",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af99884400da37c88f5e9146b7f1fd0fbcae8f6eec4e9da38b67d05486f814a6"
+dependencies = [
+ "itoa",
  "serde",
 ]
 
@@ -7249,8 +7278,10 @@ dependencies = [
  "futures-util",
  "pin-project-lite",
  "sync_wrapper 0.1.2",
+ "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4678,7 +4678,6 @@ dependencies = [
  "reqwest 0.12.9",
  "serde",
  "serde_json",
- "serial_test",
  "solana-client",
  "solana-listener",
  "solana-sdk",
@@ -5033,15 +5032,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
-name = "scc"
-version = "2.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66b202022bb57c049555430e11fc22fea12909276a80a4c3d368da36ac1d88ed"
-dependencies = [
- "sdd",
-]
-
-[[package]]
 name = "schannel"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5091,12 +5081,6 @@ dependencies = [
  "ring 0.17.8",
  "untrusted 0.9.0",
 ]
-
-[[package]]
-name = "sdd"
-version = "3.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49c1eeaf4b6a87c7479688c6d52b9f1153cedd3c489300564f932b065c6eab95"
 
 [[package]]
 name = "seahash"
@@ -5293,31 +5277,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d846214a9854ef724f3da161b426242d8de7c1fc7de2f89bb1efcb154dca79d"
 dependencies = [
  "darling",
- "proc-macro2 1.0.92",
- "quote 1.0.37",
- "syn 2.0.90",
-]
-
-[[package]]
-name = "serial_test"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b258109f244e1d6891bf1053a55d63a5cd4f8f4c30cf9a1280989f80e7a1fa9"
-dependencies = [
- "futures",
- "log",
- "once_cell",
- "parking_lot",
- "scc",
- "serial_test_derive",
-]
-
-[[package]]
-name = "serial_test_derive"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
-dependencies = [
  "proc-macro2 1.0.92",
  "quote 1.0.37",
  "syn 2.0.90",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,6 +131,7 @@ color-eyre = "0.6"
 
 # HTTP
 reqwest = { version = "0.12", default-features = false, features = ["json", "gzip", "deflate", "rustls-tls", "stream", "http2"] }
+axum = "0.7.9"
 
 # Solana
 solana-client = "=2.0.16"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,10 +121,11 @@ serde_json = "1"
 simd-json = "0.14"
 
 # Tests
-rstest = { version = "0.23" }
-test-log = { version = "0.2", features = ["trace"], default-features = false }
-pretty_assertions = "1"
 mockall = "0.13"
+pretty_assertions = "1"
+rstest = { version = "0.23" }
+serial_test = "3.2"
+test-log = { version = "0.2", features = ["trace"], default-features = false }
 
 # Errors
 eyre = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,13 +80,13 @@ relayer-amplifier-state = { git = "https://github.com/eigerco/axelar-relayer-cor
 core-common-serde-utils = { git = "https://github.com/eigerco/axelar-relayer-core.git", package = "common-serde-utils", branch = "main" }
 
 # Solana Gateway
-axelar-solana-gateway = { git = "https://github.com/eigerco/solana-axelar.git", rev = "91c8cf2", features = ["no-entrypoint"] }
-axelar-solana-its = { git = "https://github.com/eigerco/solana-axelar.git", rev = "91c8cf2", features = ["no-entrypoint"] }
-axelar-solana-governance = { git = "https://github.com/eigerco/solana-axelar.git", rev = "91c8cf2", features = ["no-entrypoint"] }
-gateway-event-stack = { git = "https://github.com/eigerco/solana-axelar.git", rev = "91c8cf2" }
-axelar-solana-encoding = { git = "https://github.com/eigerco/solana-axelar.git", rev = "91c8cf2" }
-axelar-message-primitives = { git = "https://github.com/eigerco/solana-axelar.git", rev = "91c8cf2" }
-axelar-executable = { git = "https://github.com/eigerco/solana-axelar.git", rev = "91c8cf2" }
+axelar-solana-gateway = { git = "https://github.com/eigerco/solana-axelar.git", rev = "e212e33", features = ["no-entrypoint"] }
+axelar-solana-its = { git = "https://github.com/eigerco/solana-axelar.git", rev = "e212e33", features = ["no-entrypoint"] }
+axelar-solana-governance = { git = "https://github.com/eigerco/solana-axelar.git", rev = "e212e33", features = ["no-entrypoint"] }
+gateway-event-stack = { git = "https://github.com/eigerco/solana-axelar.git", rev = "e212e33" }
+axelar-solana-encoding = { git = "https://github.com/eigerco/solana-axelar.git", rev = "e212e33" }
+axelar-message-primitives = { git = "https://github.com/eigerco/solana-axelar.git", rev = "e212e33" }
+axelar-executable = { git = "https://github.com/eigerco/solana-axelar.git", rev = "e212e33" }
 
 # CLI
 clap = { version = "4", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ solana-listener = { path = "crates/solana-listener" }
 common-serde-utils = { path = "crates/common-serde-utils" }
 solana-event-forwarder = { path = "crates/solana-event-forwarder" }
 solana-tx-pusher = { path = "crates/solana-tx-pusher" }
+rest-service = { path = "crates/rest-service" }
 retrying-solana-http-sender = { path = "crates/retrying-solana-http-sender" }
 solana-gateway-task-processor = { path = "crates/solana-gateway-task-processor" }
 effective-tx-sender = { path = "crates/effective-tx-sender" }
@@ -130,8 +131,9 @@ eyre = "0.6"
 color-eyre = "0.6"
 
 # HTTP
-reqwest = { version = "0.12", default-features = false, features = ["json", "gzip", "deflate", "rustls-tls", "stream", "http2"] }
 axum = "0.7.9"
+reqwest = { version = "0.12", default-features = false, features = ["json", "gzip", "deflate", "rustls-tls", "stream", "http2"] }
+tower-http = { version = "0.6.2", features = ["trace"] }
 
 # Solana
 solana-client = "=2.0.16"

--- a/crates/rest-service/Cargo.toml
+++ b/crates/rest-service/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "rest-service"
+version.workspace = true
+authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+license.workspace = true
+edition.workspace = true
+
+[dependencies]
+axum.workspace = true
+eyre.workspace = true
+futures.workspace = true
+relayer-engine.workspace = true
+tokio.workspace = true
+
+[lints]
+workspace = true

--- a/crates/rest-service/Cargo.toml
+++ b/crates/rest-service/Cargo.toml
@@ -29,7 +29,6 @@ tracing.workspace = true
 [dev-dependencies]
 reqwest.workspace = true
 serde_json.workspace = true
-serial_test.workspace = true
 test-log.workspace = true
 
 [lints]

--- a/crates/rest-service/Cargo.toml
+++ b/crates/rest-service/Cargo.toml
@@ -9,9 +9,11 @@ edition.workspace = true
 
 [dependencies]
 amplifier-api.workspace = true
+axelar-solana-gateway.workspace = true
 axum.workspace = true
 eyre.workspace = true
 futures.workspace = true
+gateway-event-stack.workspace = true
 indoc.workspace = true
 relayer-amplifier-api-integration.workspace = true
 relayer-engine.workspace = true
@@ -24,14 +26,10 @@ tokio.workspace = true
 tower-http.workspace = true
 tracing.workspace = true
 
-axelar-solana-gateway = { git = "ssh://git@github.com/eigerco/solana-axelar-internal.git", branch = "feat/gtw-large-outgoing-messages" , features = ["no-entrypoint"] }
-gateway-event-stack = { git = "ssh://git@github.com/eigerco/solana-axelar-internal.git", branch = "feat/gtw-large-outgoing-messages" }
-
 [dev-dependencies]
 reqwest.workspace = true
 serde_json.workspace = true
 test-log.workspace = true
-tracing-subscriber.workspace = true
 
 [lints]
 workspace = true

--- a/crates/rest-service/Cargo.toml
+++ b/crates/rest-service/Cargo.toml
@@ -29,6 +29,7 @@ tracing.workspace = true
 [dev-dependencies]
 reqwest.workspace = true
 serde_json.workspace = true
+serial_test.workspace = true
 test-log.workspace = true
 
 [lints]

--- a/crates/rest-service/Cargo.toml
+++ b/crates/rest-service/Cargo.toml
@@ -8,11 +8,30 @@ license.workspace = true
 edition.workspace = true
 
 [dependencies]
+amplifier-api.workspace = true
 axum.workspace = true
 eyre.workspace = true
 futures.workspace = true
+indoc.workspace = true
+relayer-amplifier-api-integration.workspace = true
 relayer-engine.workspace = true
+serde.workspace = true
+solana-client.workspace = true
+solana-listener.workspace = true
+solana-sdk.workspace = true
+thiserror.workspace = true
 tokio.workspace = true
+tower-http.workspace = true
+tracing.workspace = true
+
+axelar-solana-gateway = { git = "ssh://git@github.com/eigerco/solana-axelar-internal.git", branch = "feat/gtw-large-outgoing-messages" , features = ["no-entrypoint"] }
+gateway-event-stack = { git = "ssh://git@github.com/eigerco/solana-axelar-internal.git", branch = "feat/gtw-large-outgoing-messages" }
+
+[dev-dependencies]
+reqwest.workspace = true
+serde_json.workspace = true
+test-log.workspace = true
+tracing-subscriber.workspace = true
 
 [lints]
 workspace = true

--- a/crates/rest-service/src/component.rs
+++ b/crates/rest-service/src/component.rs
@@ -1,13 +1,28 @@
-use core::future::Future;
-use core::net::SocketAddrV4;
-use core::pin::Pin;
+//! REST service component for the relayer.
+use core::future::{Future, IntoFuture as _};
+use core::net::SocketAddr;
+use core::pin::{pin, Pin};
+use core::time::Duration;
+use std::sync::Arc;
 
+use axum::body::Body;
+use axum::extract::DefaultBodyLimit;
+use axum::http::{Request, Response};
 use axum::Router;
+use futures::future::{select, Either};
+use relayer_amplifier_api_integration::AmplifierCommandClient;
+use solana_client::nonblocking::rpc_client::RpcClient;
+use tower_http::trace::TraceLayer;
+use tracing::Span;
 
-/// TODO: Doc
+use crate::{endpoints, Config};
+
+/// The REST service component for the relayer.
+#[derive(Debug)]
 pub struct RestService {
     router: Router,
-    socket_addr: SocketAddrV4,
+    socket_addr: SocketAddr,
+    shutdown_rx: tokio::sync::mpsc::Receiver<eyre::Error>,
 }
 
 impl relayer_engine::RelayerComponent for RestService {
@@ -18,22 +33,100 @@ impl relayer_engine::RelayerComponent for RestService {
     }
 }
 
+pub(crate) struct ServiceState {
+    chain_name: String,
+    rpc_client: Arc<RpcClient>,
+    amplifier_client: AmplifierCommandClient,
+    shutdown_tx: tokio::sync::mpsc::Sender<eyre::Error>,
+}
+
+impl ServiceState {
+    pub(crate) fn rpc_client(&self) -> Arc<RpcClient> {
+        Arc::clone(&self.rpc_client)
+    }
+
+    pub(crate) fn chain_name(&self) -> &str {
+        &self.chain_name
+    }
+
+    pub(crate) const fn amplifier_client(&self) -> &AmplifierCommandClient {
+        &self.amplifier_client
+    }
+
+    pub(crate) async fn shutdown(&self, error: eyre::Error) {
+        self.shutdown_tx
+            .send(error)
+            .await
+            .expect("Failed to send shutdown signal");
+    }
+}
+
 impl RestService {
+    /// Create a new REST service component.
     #[must_use]
-    /// TODO: Doc
-    pub fn new(config: &crate::Config) -> Self {
-        let router = Router::new();
+    pub fn new(
+        config: &Config,
+        chain_name: String,
+        rpc_client: Arc<RpcClient>,
+        amplifier_client: AmplifierCommandClient,
+    ) -> Self {
+        let (shutdown_tx, shutdown_rx) = tokio::sync::mpsc::channel(1);
+        let state = ServiceState {
+            chain_name,
+            rpc_client,
+            amplifier_client,
+            shutdown_tx,
+        };
+        let router = Router::new()
+            .route(
+                endpoints::call_contract_offchain_data::PATH,
+                endpoints::call_contract_offchain_data::handlers(),
+            )
+            .with_state(Arc::new(state))
+            .layer(DefaultBodyLimit::max(
+                config.call_contract_offchain_data_size_limit,
+            ))
+            .layer(TraceLayer::new_for_http().make_span_with(|req: &Request<Body>| {
+                tracing::info_span!("", method = %req.method(), uri = %req.uri())
+            }).on_response(|res: &Response<Body>, latency: Duration, _span: &Span| {
+                if res.status().is_server_error() {
+                    tracing::error!(status = %res.status().as_u16(), latency = ?latency);
+                } else if res.status().is_client_error() {
+                    tracing::warn!(status = %res.status().as_u16(), latency = ?latency);
+                } else {
+                    tracing::info!(status = %res.status().as_u16(), latency = ?latency);
+                }
+            }).on_failure(()));
 
         Self {
             router,
-            socket_addr: config.socket_addr,
+            socket_addr: config.bind_addr,
+            shutdown_rx,
         }
     }
 
-    async fn process_internal(self) -> eyre::Result<()> {
-        let listener = tokio::net::TcpListener::bind(self.socket_addr).await?;
-        axum::serve(listener, self.router).await?;
+    async fn process_internal(mut self) -> eyre::Result<()> {
+        fn bail() -> Result<(), eyre::Error> {
+            Err(eyre::eyre!("REST service unexpectedly shut down"))
+        }
 
-        Ok(())
+        let listener = tokio::net::TcpListener::bind(self.socket_addr).await?;
+        tracing::info!("REST Service Listening on {}", listener.local_addr()?);
+
+        match select(
+            pin!(self.shutdown_rx.recv()),
+            axum::serve(listener, self.router).into_future(),
+        )
+        .await
+        {
+            Either::Left((result, _)) => match result {
+                Some(err) => {
+                    tracing::info!("Shutting down REST service due to internal error");
+                    Err(err)
+                }
+                _ => bail(),
+            },
+            Either::Right((_, _)) => bail(),
+        }
     }
 }

--- a/crates/rest-service/src/component.rs
+++ b/crates/rest-service/src/component.rs
@@ -79,6 +79,10 @@ impl RestService {
         };
         let router = Router::new()
             .route(
+                endpoints::health::PATH,
+                endpoints::health::handlers(),
+            )
+            .route(
                 endpoints::call_contract_offchain_data::PATH,
                 endpoints::call_contract_offchain_data::handlers(),
             )

--- a/crates/rest-service/src/component.rs
+++ b/crates/rest-service/src/component.rs
@@ -1,0 +1,39 @@
+use core::future::Future;
+use core::net::SocketAddrV4;
+use core::pin::Pin;
+
+use axum::Router;
+
+/// TODO: Doc
+pub struct RestService {
+    router: Router,
+    socket_addr: SocketAddrV4,
+}
+
+impl relayer_engine::RelayerComponent for RestService {
+    fn process(self: Box<Self>) -> Pin<Box<dyn Future<Output = eyre::Result<()>> + Send>> {
+        use futures::FutureExt as _;
+
+        self.process_internal().boxed()
+    }
+}
+
+impl RestService {
+    #[must_use]
+    /// TODO: Doc
+    pub fn new(config: &crate::Config) -> Self {
+        let router = Router::new();
+
+        Self {
+            router,
+            socket_addr: config.socket_addr,
+        }
+    }
+
+    async fn process_internal(self) -> eyre::Result<()> {
+        let listener = tokio::net::TcpListener::bind(self.socket_addr).await?;
+        axum::serve(listener, self.router).await?;
+
+        Ok(())
+    }
+}

--- a/crates/rest-service/src/config.rs
+++ b/crates/rest-service/src/config.rs
@@ -1,0 +1,12 @@
+use core::net::SocketAddr;
+
+use serde::{Deserialize, Serialize};
+
+/// Configuration for the REST service.
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
+pub struct Config {
+    /// The socket address to bind to.
+    pub bind_addr: SocketAddr,
+    /// The maximum size of the data in a contract call with offchain data handling.
+    pub call_contract_offchain_data_size_limit: usize,
+}

--- a/crates/rest-service/src/endpoints/call_contract_offchain_data.rs
+++ b/crates/rest-service/src/endpoints/call_contract_offchain_data.rs
@@ -1,0 +1,191 @@
+//! Endpoint for calling a contract with offchain data.
+use core::str::FromStr as _;
+use std::sync::Arc;
+
+use amplifier_api::types::{
+    CallEvent, CallEventMetadata, Event, EventBase, EventId, EventMetadata, GatewayV2Message,
+    MessageId, PublishEventsRequest, TxId,
+};
+use axelar_solana_gateway::processor::{CallContractOffchainDataEvent, GatewayEvent};
+use axum::body::Bytes;
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use axum::routing::{post, MethodRouter};
+use futures::channel::mpsc::UnboundedSender;
+use futures::SinkExt as _;
+use gateway_event_stack::{MatchContext, ProgramInvocationState};
+use relayer_amplifier_api_integration::AmplifierCommand;
+use solana_client::nonblocking::rpc_client::RpcClient;
+use solana_listener::{fetch_logs, SolanaTransaction};
+use solana_sdk::signature::Signature;
+use thiserror::Error;
+
+use crate::component::ServiceState;
+
+pub(crate) const PATH: &str = "/call-contract-offchain-data/:signature";
+pub(crate) fn handlers() -> MethodRouter<Arc<ServiceState>> {
+    post(post_handler)
+}
+
+#[derive(Debug, Error)]
+pub(crate) enum CallContractOffchainDataError {
+    #[error("Failed to fetch transaction logs")]
+    FailedToFetchTransactionLogs(#[from] eyre::Report),
+
+    #[error("Payload hashes don't match")]
+    PayloadHashMismatch,
+
+    #[error("Successful transaction with CallContractOffchainDataEvent not found")]
+    EventNotFound,
+
+    #[error("Failed to relay message to Axelar Amplifier")]
+    FailedToRelayToAmplifier,
+
+    #[error("Invalid transaction signature")]
+    InvalidTransactionSignature,
+}
+
+impl IntoResponse for CallContractOffchainDataError {
+    fn into_response(self) -> axum::response::Response {
+        let error_tuple = match self {
+            Self::FailedToRelayToAmplifier => (StatusCode::INTERNAL_SERVER_ERROR, self.to_string()),
+            Self::FailedToFetchTransactionLogs(_) |
+            Self::PayloadHashMismatch |
+            Self::InvalidTransactionSignature => (StatusCode::BAD_REQUEST, self.to_string()),
+            Self::EventNotFound => (StatusCode::NOT_FOUND, self.to_string()),
+        };
+
+        error_tuple.into_response()
+    }
+}
+
+// #[instrument(skip_all, fields(signature = Empty))]
+async fn post_handler(
+    State(state): State<Arc<ServiceState>>,
+    Path(signature): Path<String>,
+    payload: Bytes,
+) -> Result<(), CallContractOffchainDataError> {
+    let Ok(parsed_signature) = Signature::from_str(&signature) else {
+        tracing::warn!("Invalid transaction signature");
+        return Err(CallContractOffchainDataError::InvalidTransactionSignature);
+    };
+    let data = payload.to_vec();
+
+    let result = try_build_and_push_event_with_data(
+        data,
+        parsed_signature,
+        state.chain_name().to_owned(),
+        state.rpc_client(),
+        state.amplifier_client().sender.clone(),
+    )
+    .await;
+
+    match result {
+        Ok(()) => tracing::info!("CallContract data successfully forwarded to Axelar Amplifier"),
+        Err(CallContractOffchainDataError::FailedToRelayToAmplifier) => {
+            tracing::error!("Irrecoverable error: Communication with Axelar Amplifier was lost");
+            state
+                .shutdown(CallContractOffchainDataError::FailedToRelayToAmplifier.into())
+                .await;
+        }
+        Err(ref report) => {
+            tracing::warn!("Failed to forward message to Axelar: {report}");
+        }
+    }
+
+    result
+}
+
+async fn try_build_and_push_event_with_data(
+    data: Vec<u8>,
+    signature: Signature,
+    chain_name: String,
+    solana_rpc_client: Arc<RpcClient>,
+    mut amplifier_channel: UnboundedSender<AmplifierCommand>,
+) -> Result<(), CallContractOffchainDataError> {
+    let solana_transaction = fetch_logs(signature, &solana_rpc_client).await?;
+    let hash = solana_sdk::keccak::hash(&data).to_bytes();
+    let match_context = MatchContext::new(&axelar_solana_gateway::id().to_string());
+    let invocations = gateway_event_stack::build_program_event_stack(
+        &match_context,
+        solana_transaction.logs.as_slice(),
+        gateway_event_stack::parse_gateway_logs,
+    );
+    let mut events_iter = invocations
+        .into_iter()
+        .filter_map(|inv| match inv {
+            ProgramInvocationState::Succeeded(events) => Some(events),
+            ProgramInvocationState::InProgress(_) | ProgramInvocationState::Failed(_) => None,
+        })
+        .flatten();
+    let maybe_event = events_iter.find_map(|(idx, event)| {
+        if let GatewayEvent::CallContractOffchainData(event_data) = event {
+            Some((idx, event_data))
+        } else {
+            None
+        }
+    });
+
+    match maybe_event {
+        Some((idx, event_data)) if event_data.payload_hash == hash => {
+            let amplifier_event =
+                build_amplifier_event(chain_name, &solana_transaction, event_data, data, idx);
+            let command = AmplifierCommand::PublishEvents(PublishEventsRequest {
+                events: vec![amplifier_event],
+            });
+
+            amplifier_channel
+                .send(command)
+                .await
+                .map_err(|_err| CallContractOffchainDataError::FailedToRelayToAmplifier)?;
+
+            Ok(())
+        }
+        Some(_) => Err(CallContractOffchainDataError::PayloadHashMismatch),
+        None => Err(CallContractOffchainDataError::EventNotFound),
+    }
+}
+
+fn build_amplifier_event(
+    source_chain: String,
+    transaction: &SolanaTransaction,
+    solana_event: CallContractOffchainDataEvent,
+    payload: Vec<u8>,
+    log_index: usize,
+) -> Event {
+    let tx_id = TxId(transaction.signature.to_string());
+    let message_id = MessageId::new(&transaction.signature.to_string(), log_index);
+    let event_id = EventId::new(&transaction.signature.to_string(), log_index);
+    let source_address = solana_event.sender_key.to_string();
+
+    Event::Call(
+        CallEvent::builder()
+            .base(
+                EventBase::builder()
+                    .event_id(event_id)
+                    .meta(Some(
+                        EventMetadata::builder()
+                            .tx_id(Some(tx_id))
+                            .timestamp(transaction.timestamp)
+                            .from_address(Some(source_address.clone()))
+                            .finalized(Some(true))
+                            .extra(CallEventMetadata::builder().build())
+                            .build(),
+                    ))
+                    .build(),
+            )
+            .message(
+                GatewayV2Message::builder()
+                    .message_id(message_id)
+                    .source_chain(source_chain)
+                    .source_address(source_address)
+                    .destination_address(solana_event.destination_contract_address)
+                    .payload_hash(solana_event.payload_hash.to_vec())
+                    .build(),
+            )
+            .destination_chain(solana_event.destination_chain)
+            .payload(payload)
+            .build(),
+    )
+}

--- a/crates/rest-service/src/endpoints/call_contract_offchain_data.rs
+++ b/crates/rest-service/src/endpoints/call_contract_offchain_data.rs
@@ -60,7 +60,6 @@ impl IntoResponse for CallContractOffchainDataError {
     }
 }
 
-// #[instrument(skip_all, fields(signature = Empty))]
 async fn post_handler(
     State(state): State<Arc<ServiceState>>,
     Path(signature): Path<String>,
@@ -112,6 +111,7 @@ async fn try_build_and_push_event_with_data(
         solana_transaction.logs.as_slice(),
         gateway_event_stack::parse_gateway_logs,
     );
+
     let mut events_iter = invocations
         .into_iter()
         .filter_map(|inv| match inv {

--- a/crates/rest-service/src/endpoints/health.rs
+++ b/crates/rest-service/src/endpoints/health.rs
@@ -1,0 +1,13 @@
+//! Health endpoint, returns 200 OK if the service is up and running.
+use std::sync::Arc;
+
+use axum::routing::{get, MethodRouter};
+
+use crate::component::ServiceState;
+
+pub(crate) const PATH: &str = "/health";
+pub(crate) fn handlers() -> MethodRouter<Arc<ServiceState>> {
+    get(get_handler)
+}
+
+async fn get_handler() {}

--- a/crates/rest-service/src/endpoints/mod.rs
+++ b/crates/rest-service/src/endpoints/mod.rs
@@ -1,0 +1,2 @@
+//! Endpoint handlers for the REST service.
+pub(crate) mod call_contract_offchain_data;

--- a/crates/rest-service/src/endpoints/mod.rs
+++ b/crates/rest-service/src/endpoints/mod.rs
@@ -1,2 +1,3 @@
 //! Endpoint handlers for the REST service.
 pub(crate) mod call_contract_offchain_data;
+pub(crate) mod health;

--- a/crates/rest-service/src/lib.rs
+++ b/crates/rest-service/src/lib.rs
@@ -1,0 +1,7 @@
+use std::net::SocketAddrV4;
+
+pub mod component;
+
+pub struct Config {
+    pub socket_addr: SocketAddrV4,
+}

--- a/crates/rest-service/src/lib.rs
+++ b/crates/rest-service/src/lib.rs
@@ -1,7 +1,7 @@
-use std::net::SocketAddrV4;
+//! This crate provides a REST service component for the relayer.
+mod component;
+mod config;
+mod endpoints;
 
-pub mod component;
-
-pub struct Config {
-    pub socket_addr: SocketAddrV4,
-}
+pub use component::RestService;
+pub use config::Config;

--- a/crates/rest-service/tests/call_contract_offchain_data.rs
+++ b/crates/rest-service/tests/call_contract_offchain_data.rs
@@ -11,7 +11,6 @@ use indoc::indoc;
 use relayer_amplifier_api_integration::{AmplifierCommand, AmplifierCommandClient};
 use relayer_engine::RelayerComponent as _;
 use serde_json::{json, Value};
-use serial_test::serial;
 use solana_client::nonblocking::rpc_client::RpcClient;
 use solana_client::rpc_request::RpcRequest;
 use test_log::test;
@@ -54,7 +53,6 @@ const RESPONSE_JSON: &str = indoc! {r#"
 };
 
 #[test(tokio::test)]
-#[serial]
 async fn test_successful_call_contract_offchain_data() {
     let config = rest_service::Config {
         bind_addr: "127.0.0.1:8080".parse().unwrap(),
@@ -134,7 +132,6 @@ async fn test_successful_call_contract_offchain_data() {
 }
 
 #[test(tokio::test)]
-#[serial]
 async fn test_fail_call_contract_offchain_data_too_big() {
     let config = rest_service::Config {
         bind_addr: "127.0.0.1:8080".parse().unwrap(),
@@ -199,7 +196,6 @@ async fn test_fail_call_contract_offchain_data_too_big() {
 }
 
 #[test(tokio::test)]
-#[serial]
 async fn test_fail_call_contract_offchain_data_invalid_signature() {
     let config = rest_service::Config {
         bind_addr: "127.0.0.1:8080".parse().unwrap(),
@@ -265,7 +261,6 @@ async fn test_fail_call_contract_offchain_data_invalid_signature() {
 }
 
 #[test(tokio::test)]
-#[serial]
 async fn test_fail_call_contract_offchain_data_invalid_data() {
     let config = rest_service::Config {
         bind_addr: "127.0.0.1:8080".parse().unwrap(),
@@ -325,7 +320,6 @@ async fn test_fail_call_contract_offchain_data_invalid_data() {
 }
 
 #[test(tokio::test)]
-#[serial]
 async fn test_fail_call_contract_offchain_data_on_tx_fetch_error() {
     let config = rest_service::Config {
         bind_addr: "127.0.0.1:8080".parse().unwrap(),
@@ -389,7 +383,6 @@ async fn test_fail_call_contract_offchain_data_on_tx_fetch_error() {
 }
 
 #[test(tokio::test)]
-#[serial]
 #[expect(clippy::indexing_slicing, reason = "It's fine to panic in tests")]
 async fn test_fail_call_contract_offchain_data_on_event_not_found() {
     let config = rest_service::Config {

--- a/crates/rest-service/tests/call_contract_offchain_data.rs
+++ b/crates/rest-service/tests/call_contract_offchain_data.rs
@@ -35,11 +35,11 @@ const RESPONSE_JSON: &str = indoc! {r#"
         "Program log: Invalid instruction data: [2, 136, 4, 0, 0, 240, 159, 144, 170, 240, 159, 144, 170, 240, 159, 144]",
         "Program log: Instruction: Native",
         "Program log: Instruction: SendToGateway",
-        "Program gtwgM94UYHwBh3g7rWi1tcpkgELxHQRLPpPHsaECW57 invoke [2]",
+        "Program gtwLjHAsfKAR6GWB4hzTUAA1w4SDdFMKamtGA5ttMEe invoke [2]",
         "Program log: Instruction: Call Contract Offchain Data",
         "Program data: b2ZmY2hhaW4gZGF0YV9fXw== 6NGe5cm7PkXHz/g8V2VdRg0nU0l7R48x8lll4s0Clz0= ik8DocGbvnSCYaX9IUJZUapVH+LFQmwjbrT91ZGn450= ZXRoZXJldW0= MHgwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDBhZmRlMGY1MWU2OTJmMGU0YmZkNDVkMGYyYmI2ODRmYjM3YmZjNjQz",
-        "Program gtwgM94UYHwBh3g7rWi1tcpkgELxHQRLPpPHsaECW57 consumed 4452 of 172724 compute units",
-        "Program gtwgM94UYHwBh3g7rWi1tcpkgELxHQRLPpPHsaECW57 success",
+        "Program gtwLjHAsfKAR6GWB4hzTUAA1w4SDdFMKamtGA5ttMEe consumed 4452 of 172724 compute units",
+        "Program gtwLjHAsfKAR6GWB4hzTUAA1w4SDdFMKamtGA5ttMEe success",
         "Program memQuKMGBounhwP5yw9qomYNU97Eqcx9c4XwDUo6uGV consumed 31849 of 200000 compute units",
         "Program memQuKMGBounhwP5yw9qomYNU97Eqcx9c4XwDUo6uGV success"
       ],
@@ -261,14 +261,7 @@ async fn test_fail_call_contract_offchain_data_invalid_data() {
     });
 
     #[expect(clippy::non_ascii_literal, reason = "Test code")]
-    let memo = "🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪
-    🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪
-    🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪
-    🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪
-    🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪
-    🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪
-    🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪
-    🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪"
+    let memo = "🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪"
         .to_owned()
         .replace(['\n', ' '], "");
     let memo_bytes = memo.as_bytes().to_vec();

--- a/crates/rest-service/tests/call_contract_offchain_data.rs
+++ b/crates/rest-service/tests/call_contract_offchain_data.rs
@@ -10,6 +10,7 @@ use futures::StreamExt as _;
 use indoc::indoc;
 use relayer_amplifier_api_integration::{AmplifierCommand, AmplifierCommandClient};
 use relayer_engine::RelayerComponent as _;
+use reqwest::StatusCode;
 use serde_json::{json, Value};
 use solana_client::nonblocking::rpc_client::RpcClient;
 use solana_client::rpc_request::RpcRequest;
@@ -51,6 +52,17 @@ const RESPONSE_JSON: &str = indoc! {r#"
 }
 "#
 };
+
+async fn wait_for_server(client: &reqwest::Client) {
+    let url = "http://127.0.0.1:8080/health";
+    loop {
+        let result = client.get(url).send().await;
+        match result {
+            Ok(res) if res.status() == StatusCode::OK => break,
+            Ok(_) | Err(_) => continue,
+        }
+    }
+}
 
 #[test(tokio::test)]
 async fn test_successful_call_contract_offchain_data() {
@@ -176,8 +188,8 @@ async fn test_fail_call_contract_offchain_data_too_big() {
         .replace(['\n', ' '], "");
     let memo_bytes = memo.as_bytes().to_vec();
 
-    tokio::time::sleep(Duration::from_secs(1)).await;
     let client = reqwest::Client::new();
+    wait_for_server(&client).await;
     let url = format!("http://127.0.0.1:8080/call-contract-offchain-data/{encoded_signature}");
     let Ok(response) = client.post(url).body(memo_bytes).send().await else {
         panic!("Expected response");
@@ -238,8 +250,8 @@ async fn test_fail_call_contract_offchain_data_invalid_signature() {
         .replace(['\n', ' '], "");
     let memo_bytes = memo.as_bytes().to_vec();
 
-    tokio::time::sleep(Duration::from_secs(1)).await;
     let client = reqwest::Client::new();
+    wait_for_server(&client).await;
     let url = format!("http://127.0.0.1:8080/call-contract-offchain-data/{encoded_signature}");
     let Ok(response) = client.post(url).body(memo_bytes).send().await else {
         panic!("Expected response");
@@ -297,8 +309,8 @@ async fn test_fail_call_contract_offchain_data_invalid_data() {
         .replace(['\n', ' '], "");
     let memo_bytes = memo.as_bytes().to_vec();
 
-    tokio::time::sleep(Duration::from_secs(1)).await;
     let client = reqwest::Client::new();
+    wait_for_server(&client).await;
     let url = format!("http://127.0.0.1:8080/call-contract-offchain-data/{encoded_signature}");
     let Ok(response) = client.post(url).body(memo_bytes).send().await else {
         panic!("Expected response");
@@ -360,8 +372,8 @@ async fn test_fail_call_contract_offchain_data_on_tx_fetch_error() {
         .replace(['\n', ' '], "");
     let memo_bytes = memo.as_bytes().to_vec();
 
-    tokio::time::sleep(Duration::from_secs(1)).await;
     let client = reqwest::Client::new();
+    wait_for_server(&client).await;
     let url = format!("http://127.0.0.1:8080/call-contract-offchain-data/{encoded_signature}");
     let Ok(response) = client.post(url).body(memo_bytes).send().await else {
         panic!("Expected response");
@@ -431,8 +443,8 @@ async fn test_fail_call_contract_offchain_data_on_event_not_found() {
         .replace(['\n', ' '], "");
     let memo_bytes = memo.as_bytes().to_vec();
 
-    tokio::time::sleep(Duration::from_secs(1)).await;
     let client = reqwest::Client::new();
+    wait_for_server(&client).await;
     let url = format!("http://127.0.0.1:8080/call-contract-offchain-data/{encoded_signature}");
     let Ok(response) = client.post(url).body(memo_bytes).send().await else {
         panic!("Expected response");

--- a/crates/rest-service/tests/call_contract_offchain_data.rs
+++ b/crates/rest-service/tests/call_contract_offchain_data.rs
@@ -11,6 +11,7 @@ use indoc::indoc;
 use relayer_amplifier_api_integration::{AmplifierCommand, AmplifierCommandClient};
 use relayer_engine::RelayerComponent as _;
 use serde_json::{json, Value};
+use serial_test::serial;
 use solana_client::nonblocking::rpc_client::RpcClient;
 use solana_client::rpc_request::RpcRequest;
 use test_log::test;
@@ -53,6 +54,7 @@ const RESPONSE_JSON: &str = indoc! {r#"
 };
 
 #[test(tokio::test)]
+#[serial]
 async fn test_successful_call_contract_offchain_data() {
     let config = rest_service::Config {
         bind_addr: "127.0.0.1:8080".parse().unwrap(),
@@ -122,6 +124,7 @@ async fn test_successful_call_contract_offchain_data() {
 }
 
 #[test(tokio::test)]
+#[serial]
 async fn test_fail_call_contract_offchain_data_too_big() {
     let config = rest_service::Config {
         bind_addr: "127.0.0.1:8080".parse().unwrap(),
@@ -176,6 +179,7 @@ async fn test_fail_call_contract_offchain_data_too_big() {
 }
 
 #[test(tokio::test)]
+#[serial]
 async fn test_fail_call_contract_offchain_data_invalid_signature() {
     let config = rest_service::Config {
         bind_addr: "127.0.0.1:8080".parse().unwrap(),
@@ -231,6 +235,7 @@ async fn test_fail_call_contract_offchain_data_invalid_signature() {
 }
 
 #[test(tokio::test)]
+#[serial]
 async fn test_fail_call_contract_offchain_data_invalid_data() {
     let config = rest_service::Config {
         bind_addr: "127.0.0.1:8080".parse().unwrap(),
@@ -280,6 +285,7 @@ async fn test_fail_call_contract_offchain_data_invalid_data() {
 }
 
 #[test(tokio::test)]
+#[serial]
 async fn test_fail_call_contract_offchain_data_on_tx_fetch_error() {
     let config = rest_service::Config {
         bind_addr: "127.0.0.1:8080".parse().unwrap(),
@@ -334,6 +340,7 @@ async fn test_fail_call_contract_offchain_data_on_tx_fetch_error() {
 }
 
 #[test(tokio::test)]
+#[serial]
 #[expect(clippy::indexing_slicing, reason = "It's fine to panic in tests")]
 async fn test_fail_call_contract_offchain_data_on_event_not_found() {
     let config = rest_service::Config {

--- a/crates/rest-service/tests/call_contract_offchain_data.rs
+++ b/crates/rest-service/tests/call_contract_offchain_data.rs
@@ -1,0 +1,403 @@
+//! Tests for call-contract-offchain-data endpoint
+#![cfg(test)]
+#![expect(clippy::non_ascii_literal, reason = "Test code")]
+use core::time::Duration;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use amplifier_api::types::{Event, PublishEventsRequest};
+use futures::StreamExt as _;
+use indoc::indoc;
+use relayer_amplifier_api_integration::{AmplifierCommand, AmplifierCommandClient};
+use relayer_engine::RelayerComponent as _;
+use serde_json::{json, Value};
+use solana_client::nonblocking::rpc_client::RpcClient;
+use solana_client::rpc_request::RpcRequest;
+use test_log::test;
+
+// The only real things here are the logs and the status, the rest is made up garbage.
+const RESPONSE_JSON: &str = indoc! {r#"
+{
+    "meta": {
+      "err": null,
+      "fee": 5000,
+      "innerInstructions": [],
+      "postBalances": [499998932500, 26858640, 1, 1, 1],
+      "postTokenBalances": [],
+      "preBalances": [499998937500, 26858640, 1, 1, 1],
+      "preTokenBalances": [],
+      "rewards": [],
+      "status": {
+        "Ok": null
+      },
+      "logMessages": [
+        "Program memQuKMGBounhwP5yw9qomYNU97Eqcx9c4XwDUo6uGV invoke [1]",
+        "Program log: Invalid instruction data: [2, 136, 4, 0, 0, 240, 159, 144, 170, 240, 159, 144, 170, 240, 159, 144]",
+        "Program log: Instruction: Native",
+        "Program log: Instruction: SendToGateway",
+        "Program gtwgM94UYHwBh3g7rWi1tcpkgELxHQRLPpPHsaECW57 invoke [2]",
+        "Program log: Instruction: Call Contract Offchain Data",
+        "Program data: b2ZmY2hhaW4gZGF0YV9fXw== 6NGe5cm7PkXHz/g8V2VdRg0nU0l7R48x8lll4s0Clz0= ik8DocGbvnSCYaX9IUJZUapVH+LFQmwjbrT91ZGn450= ZXRoZXJldW0= MHgwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDBhZmRlMGY1MWU2OTJmMGU0YmZkNDVkMGYyYmI2ODRmYjM3YmZjNjQz",
+        "Program gtwgM94UYHwBh3g7rWi1tcpkgELxHQRLPpPHsaECW57 consumed 4452 of 172724 compute units",
+        "Program gtwgM94UYHwBh3g7rWi1tcpkgELxHQRLPpPHsaECW57 success",
+        "Program memQuKMGBounhwP5yw9qomYNU97Eqcx9c4XwDUo6uGV consumed 31849 of 200000 compute units",
+        "Program memQuKMGBounhwP5yw9qomYNU97Eqcx9c4XwDUo6uGV success"
+      ],
+      "computeUnitsConsumed": 31849,
+      "returnData": null
+    },
+    "slot": 430,
+    "transaction":["5EcULiPU5rnAanHzXHY1xw9tLbgWJzCvKKaja6jaf8gy6wVgKBr6xB2xU4SWTwTk58TBfSNQ37nRphcsd1gonD3WHeC9zzeByWMZanQindk1jat3G819JeDrU7y6PmQSn5xFVE3S5iaUNGGN2r3aSy2vX86T21ENjCpbvLstUyxKM56B77MeSDZkyCxFQWn8Q69eoaJPvKb2p7y922nG75PH1YFjxrKn2EQet7k4jNh6RbnD2NAU2BNRrC5BiP2N4SJC3tTunfiNbskUbjmRSxTMdaG2JWpqgYyrZfS4AbjCiULhxEvtbjJwTvRzXzaFuiEMwvr3EcoZEReDEN4XRxqSSxDMpQch9qhn2p5sUuTDzzMntpQS1Ngr2TYwro2EqjhRqQLMXt7arpbWkhMG9DDXfKEmNtRsAGk9ANM2Dw1JUeK73xQ6N7s43sRi6rE7oTKTYewfHFzsuzcSqNa4LNUzNirzAGE6PGFVw7NUoB97jbKJscYFLXfR3K1N1K4reH6S46uW4SJMs9vABDVeUFk5FpKDY9ep9rgrscxc7xcviDBkEtMqmzhLwyWyLwPcjGWfSAFxTSeVXgAj3p7ekXe5UrE49tb5vKMX91MrSbhMd45VPa7xQYwFBopfXV6PCbPjZAbwas2azZfqXUEzBai9u92yMemtTbU3BYh3g15pabKa42sWbZabrfvkPi39ue7LK6v8F4Fu275U8xRGDeibDz5MzHX4AJPfAvKAcsMhUR8G9vAcvAz4WqqPVbToatQiYf6NRceC9oGrAYSRJsSL34ATPwSdCnxJN8SAKo9k7q4aNJpp5Q1fEV5", "base58"]
+}
+"#
+};
+
+#[test(tokio::test)]
+async fn test_successful_call_contract_offchain_data() {
+    let config = rest_service::Config {
+        bind_addr: "127.0.0.1:8080".parse().unwrap(),
+        call_contract_offchain_data_size_limit: 1024 * 1024 * 1024,
+    };
+
+    let parsed_response: Value = serde_json::from_str(RESPONSE_JSON).unwrap();
+    let encoded_signature =
+        "4dy5N9UQ2pX3DrKV8ueKY6K8tdNYYRfwzhUZ3Qxj6X3t7ykEDW2t8KJcbmvvr53F67MDzhxBsu9SN3pMKYqrwAss"
+            .to_owned();
+
+    let mut mocks = HashMap::new();
+    mocks.insert(RpcRequest::GetTransaction, parsed_response);
+    let rpc_client = RpcClient::new_mock_with_mocks("succeeds".to_owned(), mocks);
+
+    let (tx, mut rx) = futures::channel::mpsc::unbounded();
+    let amplifier_client = AmplifierCommandClient { sender: tx };
+
+    let service = Box::new(rest_service::RestService::new(
+        &config,
+        "solana-devnet".to_owned(),
+        Arc::new(rpc_client),
+        amplifier_client,
+    ));
+
+    tokio::spawn(async move {
+        service.process().await.unwrap();
+    });
+
+    let memo = "🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪
+    🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪
+    🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪
+    🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪
+    🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪
+    🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪
+    🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪
+    🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪
+    🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪"
+        .to_owned()
+        .replace(['\n', ' '], "");
+    let memo_bytes = memo.as_bytes().to_vec();
+
+    tokio::spawn(async move {
+        let client = reqwest::Client::new();
+        let url = format!("http://127.0.0.1:8080/call-contract-offchain-data/{encoded_signature}");
+        client
+            .post(url)
+            .body(memo_bytes)
+            .send()
+            .await
+            .expect("Failed to send request");
+    });
+
+    let amplifier_command = tokio::time::timeout(Duration::from_secs(1), rx.next())
+        .await
+        .expect("Timed out waiting for AmplifierCommand");
+
+    let Some(AmplifierCommand::PublishEvents(PublishEventsRequest { mut events })) =
+        amplifier_command
+    else {
+        panic!("Expected PublishEvents");
+    };
+    let Some(Event::Call(metadata)) = events.pop() else {
+        panic!("Expected CallEvent");
+    };
+    assert_eq!(metadata.payload, memo.as_bytes());
+}
+
+#[test(tokio::test)]
+async fn test_fail_call_contract_offchain_data_too_big() {
+    let config = rest_service::Config {
+        bind_addr: "127.0.0.1:8080".parse().unwrap(),
+        call_contract_offchain_data_size_limit: 10,
+    };
+
+    let parsed_response: Value = serde_json::from_str(RESPONSE_JSON).unwrap();
+    let encoded_signature =
+        "4dy5N9UQ2pX3DrKV8ueKY6K8tdNYYRfwzhUZ3Qxj6X3t7ykEDW2t8KJcbmvvr53F67MDzhxBsu9SN3pMKYqrwAss"
+            .to_owned();
+
+    let mut mocks = HashMap::new();
+    mocks.insert(RpcRequest::GetTransaction, parsed_response);
+    let rpc_client = RpcClient::new_mock_with_mocks("succeeds".to_owned(), mocks);
+
+    let (tx, _rx) = futures::channel::mpsc::unbounded();
+    let amplifier_client = AmplifierCommandClient { sender: tx };
+
+    let service = Box::new(rest_service::RestService::new(
+        &config,
+        "solana-devnet".to_owned(),
+        Arc::new(rpc_client),
+        amplifier_client,
+    ));
+
+    tokio::spawn(async move {
+        service.process().await.unwrap();
+    });
+
+    #[expect(clippy::non_ascii_literal, reason = "Test code")]
+    let memo = "🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪
+    🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪
+    🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪
+    🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪
+    🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪
+    🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪
+    🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪
+    🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪
+    🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪"
+        .to_owned()
+        .replace(['\n', ' '], "");
+    let memo_bytes = memo.as_bytes().to_vec();
+
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    let client = reqwest::Client::new();
+    let url = format!("http://127.0.0.1:8080/call-contract-offchain-data/{encoded_signature}");
+    let Ok(response) = client.post(url).body(memo_bytes).send().await else {
+        panic!("Expected response");
+    };
+
+    assert_eq!(response.status(), 413);
+}
+
+#[test(tokio::test)]
+async fn test_fail_call_contract_offchain_data_invalid_signature() {
+    let config = rest_service::Config {
+        bind_addr: "127.0.0.1:8080".parse().unwrap(),
+        call_contract_offchain_data_size_limit: 10 * 1024 * 1024,
+    };
+
+    let parsed_response: Value = serde_json::from_str(RESPONSE_JSON).unwrap();
+    let encoded_signature = "3FiVfamkLFV8V4PXVVDdp7ciGn2yHxx".to_owned();
+
+    let mut mocks = HashMap::new();
+    mocks.insert(RpcRequest::GetTransaction, parsed_response);
+    let rpc_client = RpcClient::new_mock_with_mocks("succeeds".to_owned(), mocks);
+
+    let (tx, _rx) = futures::channel::mpsc::unbounded();
+    let amplifier_client = AmplifierCommandClient { sender: tx };
+
+    let service = Box::new(rest_service::RestService::new(
+        &config,
+        "solana-devnet".to_owned(),
+        Arc::new(rpc_client),
+        amplifier_client,
+    ));
+
+    tokio::spawn(async move {
+        service.process().await.unwrap();
+    });
+
+    #[expect(clippy::non_ascii_literal, reason = "Test code")]
+    let memo = "🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪
+    🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪
+    🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪
+    🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪
+    🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪
+    🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪
+    🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪
+    🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪
+    🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪"
+        .to_owned()
+        .replace(['\n', ' '], "");
+    let memo_bytes = memo.as_bytes().to_vec();
+
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    let client = reqwest::Client::new();
+    let url = format!("http://127.0.0.1:8080/call-contract-offchain-data/{encoded_signature}");
+    let Ok(response) = client.post(url).body(memo_bytes).send().await else {
+        panic!("Expected response");
+    };
+
+    assert_eq!(response.status(), 400);
+
+    let error_message = response.text().await.expect("Expected error message");
+    assert!(error_message.contains("Invalid transaction signature"));
+}
+
+#[test(tokio::test)]
+async fn test_fail_call_contract_offchain_data_invalid_data() {
+    let config = rest_service::Config {
+        bind_addr: "127.0.0.1:8080".parse().unwrap(),
+        call_contract_offchain_data_size_limit: 10 * 1024 * 1024,
+    };
+
+    let parsed_response: Value = serde_json::from_str(RESPONSE_JSON).unwrap();
+    let encoded_signature =
+        "4dy5N9UQ2pX3DrKV8ueKY6K8tdNYYRfwzhUZ3Qxj6X3t7ykEDW2t8KJcbmvvr53F67MDzhxBsu9SN3pMKYqrwAss"
+            .to_owned();
+
+    let mut mocks = HashMap::new();
+    mocks.insert(RpcRequest::GetTransaction, parsed_response);
+    let rpc_client = RpcClient::new_mock_with_mocks("succeeds".to_owned(), mocks);
+
+    let (tx, _rx) = futures::channel::mpsc::unbounded();
+    let amplifier_client = AmplifierCommandClient { sender: tx };
+
+    let service = Box::new(rest_service::RestService::new(
+        &config,
+        "solana-devnet".to_owned(),
+        Arc::new(rpc_client),
+        amplifier_client,
+    ));
+
+    tokio::spawn(async move {
+        service.process().await.unwrap();
+    });
+
+    #[expect(clippy::non_ascii_literal, reason = "Test code")]
+    let memo = "🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪
+    🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪
+    🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪
+    🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪
+    🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪
+    🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪
+    🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪
+    🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪"
+        .to_owned()
+        .replace(['\n', ' '], "");
+    let memo_bytes = memo.as_bytes().to_vec();
+
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    let client = reqwest::Client::new();
+    let url = format!("http://127.0.0.1:8080/call-contract-offchain-data/{encoded_signature}");
+    let Ok(response) = client.post(url).body(memo_bytes).send().await else {
+        panic!("Expected response");
+    };
+
+    assert_eq!(response.status(), 400);
+
+    let error_message = response.text().await.expect("Expected error message");
+    assert!(error_message.contains("Payload hashes don't match"));
+}
+
+#[test(tokio::test)]
+async fn test_fail_call_contract_offchain_data_on_tx_fetch_error() {
+    let config = rest_service::Config {
+        bind_addr: "127.0.0.1:8080".parse().unwrap(),
+        call_contract_offchain_data_size_limit: 10 * 1024 * 1024,
+    };
+
+    let encoded_signature =
+        "4dy5N9UQ2pX3DrKV8ueKY6K8tdNYYRfwzhUZ3Qxj6X3t7ykEDW2t8KJcbmvvr53F67MDzhxBsu9SN3pMKYqrwAss"
+            .to_owned();
+
+    let rpc_client = RpcClient::new_mock("fails".to_owned());
+
+    let (tx, _rx) = futures::channel::mpsc::unbounded();
+    let amplifier_client = AmplifierCommandClient { sender: tx };
+
+    let service = Box::new(rest_service::RestService::new(
+        &config,
+        "solana-devnet".to_owned(),
+        Arc::new(rpc_client),
+        amplifier_client,
+    ));
+
+    tokio::spawn(async move {
+        service.process().await.unwrap();
+    });
+
+    #[expect(clippy::non_ascii_literal, reason = "Test code")]
+    let memo = "🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪
+    🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪
+    🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪
+    🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪
+    🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪
+    🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪
+    🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪
+    🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪"
+        .to_owned()
+        .replace(['\n', ' '], "");
+    let memo_bytes = memo.as_bytes().to_vec();
+
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    let client = reqwest::Client::new();
+    let url = format!("http://127.0.0.1:8080/call-contract-offchain-data/{encoded_signature}");
+    let Ok(response) = client.post(url).body(memo_bytes).send().await else {
+        panic!("Expected response");
+    };
+
+    assert_eq!(response.status(), 400);
+
+    let error_message = response.text().await.expect("Expected error message");
+    dbg!(&error_message);
+    assert!(error_message.contains("Failed to fetch transaction logs"));
+}
+
+#[test(tokio::test)]
+#[expect(clippy::indexing_slicing, reason = "It's fine to panic in tests")]
+async fn test_fail_call_contract_offchain_data_on_event_not_found() {
+    let config = rest_service::Config {
+        bind_addr: "127.0.0.1:8080".parse().unwrap(),
+        call_contract_offchain_data_size_limit: 10 * 1024 * 1024,
+    };
+
+    let mut parsed_response: Value = serde_json::from_str(RESPONSE_JSON).unwrap();
+
+    // Remove logs so the event is not found
+    parsed_response["meta"]["logMessages"] = json!([]);
+
+    let encoded_signature =
+        "4dy5N9UQ2pX3DrKV8ueKY6K8tdNYYRfwzhUZ3Qxj6X3t7ykEDW2t8KJcbmvvr53F67MDzhxBsu9SN3pMKYqrwAss"
+            .to_owned();
+
+    let mut mocks = HashMap::new();
+    mocks.insert(RpcRequest::GetTransaction, parsed_response);
+    let rpc_client = RpcClient::new_mock_with_mocks("succeeds".to_owned(), mocks);
+
+    let (tx, _rx) = futures::channel::mpsc::unbounded();
+    let amplifier_client = AmplifierCommandClient { sender: tx };
+
+    let service = Box::new(rest_service::RestService::new(
+        &config,
+        "solana-devnet".to_owned(),
+        Arc::new(rpc_client),
+        amplifier_client,
+    ));
+
+    tokio::spawn(async move {
+        service.process().await.unwrap();
+    });
+
+    #[expect(clippy::non_ascii_literal, reason = "Test code")]
+    let memo = "🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪
+    🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪
+    🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪
+    🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪
+    🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪
+    🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪
+    🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪
+    🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪🐪"
+        .to_owned()
+        .replace(['\n', ' '], "");
+    let memo_bytes = memo.as_bytes().to_vec();
+
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    let client = reqwest::Client::new();
+    let url = format!("http://127.0.0.1:8080/call-contract-offchain-data/{encoded_signature}");
+    let Ok(response) = client.post(url).body(memo_bytes).send().await else {
+        panic!("Expected response");
+    };
+
+    assert_eq!(response.status(), 404);
+
+    let error_message = response.text().await.expect("Expected error message");
+    assert!(error_message
+        .contains("Successful transaction with CallContractOffchainDataEvent not found"));
+}

--- a/crates/solana-axelar-relayer/Cargo.toml
+++ b/crates/solana-axelar-relayer/Cargo.toml
@@ -15,6 +15,7 @@ toml.workspace = true
 tokio.workspace = true
 serde.workspace = true
 relayer-amplifier-api-integration.workspace = true
+rest-service.workspace = true
 solana-listener.workspace = true
 solana-event-forwarder.workspace = true
 solana-gateway-task-processor.workspace = true

--- a/crates/solana-axelar-relayer/src/telemetry.rs
+++ b/crates/solana-axelar-relayer/src/telemetry.rs
@@ -109,6 +109,9 @@ fn setup_subscriber(
         .add_directive("hyper=error".parse()?)
         .add_directive("tonic=error".parse()?)
         .add_directive("reqwest=error".parse()?)
+        .add_directive("rest-service=info".parse()?)
+        .add_directive("tower_http=info".parse()?)
+        .add_directive("axum=error".parse()?)
         .add_directive(EnvFilter::from_default_env().to_string().parse()?);
 
     let output_layer = tracing_subscriber::fmt::layer()

--- a/crates/solana-event-forwarder/src/component.rs
+++ b/crates/solana-event-forwarder/src/component.rs
@@ -252,5 +252,9 @@ fn map_gateway_event_to_amplifier_event(
             tracing::info!(?new_operatorship, "Operatorship transferred");
             None
         }
+        GatewayEvent::CallContractOffchainData(ref _call) => {
+            tracing::info!("CallContractOffchainData event is handled on user request");
+            None
+        }
     }
 }

--- a/crates/solana-listener/src/component.rs
+++ b/crates/solana-listener/src/component.rs
@@ -12,6 +12,7 @@ mod log_processor;
 mod signature_batch_scanner;
 mod signature_realtime_scanner;
 
+pub use log_processor::fetch_logs;
 /// Typical message with the produced work.
 /// Contains the handle to a task that resolves into a
 /// [`SolanaTransaction`].

--- a/crates/solana-listener/src/component/log_processor.rs
+++ b/crates/solana-listener/src/component/log_processor.rs
@@ -37,7 +37,15 @@ pub(crate) async fn fetch_and_send(
     Ok(())
 }
 
-pub(crate) async fn fetch_logs(
+/// Fetch the logs of a Solana transaction.
+///
+/// # Errors
+///
+/// - If request to the Solana RPC fails
+/// - If the metadata is not included with the logs
+/// - If the logs are not included
+/// - If the transaction was not successful
+pub async fn fetch_logs(
     signature: Signature,
     rpc_client: &RpcClient,
 ) -> eyre::Result<SolanaTransaction> {

--- a/crates/solana-listener/src/lib.rs
+++ b/crates/solana-listener/src/lib.rs
@@ -3,6 +3,6 @@
 mod component;
 mod config;
 
-pub use component::{SolanaListener, SolanaListenerClient, SolanaTransaction};
+pub use component::{fetch_logs, SolanaListener, SolanaListenerClient, SolanaTransaction};
 pub use config::{Config, MissedSignatureCatchupStrategy};
 pub use solana_sdk;


### PR DESCRIPTION
**Describe the changes**

Related to https://github.com/eigerco/solana-axelar-internal/issues/526

Added REST Service with endpoint aimed at supporting `CallContract` messages with large payloads that cannot be sent directly on Solana.

- [x] Tests have been added/updated for the changes.
- [x] Documentation has been updated for the changes (if applicable).
- [x] The code follows Rust's style guidelines.