### PR TITLE
fix: use `send_gateway_tx` on payload upload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -667,7 +667,7 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 [[package]]
 name = "axelar-executable"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/solana-axelar.git?branch=axelar-executable-updates#4e84c102a40320d1becdbe8f992e2e312b0b7170"
+source = "git+https://github.com/eigerco/solana-axelar.git?branch=main#7371554bb29d00a285f3df1ad17101251f00094a"
 dependencies = [
  "alloy-sol-types",
  "axelar-solana-encoding",
@@ -682,7 +682,7 @@ dependencies = [
 [[package]]
 name = "axelar-executable-old"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/solana-axelar.git?branch=axelar-executable-updates#4e84c102a40320d1becdbe8f992e2e312b0b7170"
+source = "git+https://github.com/eigerco/solana-axelar.git?branch=main#7371554bb29d00a285f3df1ad17101251f00094a"
 dependencies = [
  "axelar-message-primitives",
  "axelar-rkyv-encoding",
@@ -694,7 +694,7 @@ dependencies = [
 [[package]]
 name = "axelar-message-primitives"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/solana-axelar.git?branch=axelar-executable-updates#4e84c102a40320d1becdbe8f992e2e312b0b7170"
+source = "git+https://github.com/eigerco/solana-axelar.git?branch=main#7371554bb29d00a285f3df1ad17101251f00094a"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -710,11 +710,12 @@ dependencies = [
 [[package]]
 name = "axelar-rkyv-encoding"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/solana-axelar.git?branch=axelar-executable-updates#4e84c102a40320d1becdbe8f992e2e312b0b7170"
+source = "git+https://github.com/eigerco/solana-axelar.git?branch=main#7371554bb29d00a285f3df1ad17101251f00094a"
 dependencies = [
  "arrayref",
  "bitflags 2.6.0",
  "bnum 0.10.0",
+ "borsh 1.5.3",
  "bs58",
  "bytemuck",
  "ed25519-dalek 2.1.1",
@@ -730,7 +731,7 @@ dependencies = [
 [[package]]
 name = "axelar-solana-encoding"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/solana-axelar.git?branch=axelar-executable-updates#4e84c102a40320d1becdbe8f992e2e312b0b7170"
+source = "git+https://github.com/eigerco/solana-axelar.git?branch=main#7371554bb29d00a285f3df1ad17101251f00094a"
 dependencies = [
  "arrayref",
  "borsh 1.5.3",
@@ -747,7 +748,7 @@ dependencies = [
 [[package]]
 name = "axelar-solana-gas-service"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/solana-axelar.git?branch=axelar-executable-updates#4e84c102a40320d1becdbe8f992e2e312b0b7170"
+source = "git+https://github.com/eigerco/solana-axelar.git?branch=main#7371554bb29d00a285f3df1ad17101251f00094a"
 dependencies = [
  "borsh 1.5.3",
  "bytemuck",
@@ -761,7 +762,7 @@ dependencies = [
 [[package]]
 name = "axelar-solana-gateway"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/solana-axelar.git?branch=axelar-executable-updates#4e84c102a40320d1becdbe8f992e2e312b0b7170"
+source = "git+https://github.com/eigerco/solana-axelar.git?branch=main#7371554bb29d00a285f3df1ad17101251f00094a"
 dependencies = [
  "axelar-message-primitives",
  "axelar-solana-encoding",
@@ -776,6 +777,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "program-utils",
+ "role-management",
  "solana-program",
  "thiserror 1.0.69",
 ]
@@ -783,23 +785,23 @@ dependencies = [
 [[package]]
 name = "axelar-solana-governance"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/solana-axelar.git?branch=axelar-executable-updates#4e84c102a40320d1becdbe8f992e2e312b0b7170"
+source = "git+https://github.com/eigerco/solana-axelar.git?branch=main#7371554bb29d00a285f3df1ad17101251f00094a"
 dependencies = [
  "alloy-sol-types",
  "axelar-executable-old",
  "axelar-rkyv-encoding",
  "base64 0.21.7",
+ "borsh 1.5.3",
  "gmp-gateway",
  "governance-gmp",
  "program-utils",
- "rkyv",
  "solana-program",
 ]
 
 [[package]]
 name = "axelar-solana-its"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/solana-axelar.git?branch=axelar-executable-updates#4e84c102a40320d1becdbe8f992e2e312b0b7170"
+source = "git+https://github.com/eigerco/solana-axelar.git?branch=main#7371554bb29d00a285f3df1ad17101251f00094a"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -2343,7 +2345,7 @@ dependencies = [
 [[package]]
 name = "gateway-event-stack"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/solana-axelar.git?branch=axelar-executable-updates#4e84c102a40320d1becdbe8f992e2e312b0b7170"
+source = "git+https://github.com/eigerco/solana-axelar.git?branch=main#7371554bb29d00a285f3df1ad17101251f00094a"
 dependencies = [
  "axelar-solana-gas-service",
  "axelar-solana-gateway",
@@ -2428,7 +2430,7 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 [[package]]
 name = "gmp-gateway"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/solana-axelar.git?branch=axelar-executable-updates#4e84c102a40320d1becdbe8f992e2e312b0b7170"
+source = "git+https://github.com/eigerco/solana-axelar.git?branch=main#7371554bb29d00a285f3df1ad17101251f00094a"
 dependencies = [
  "arrayref",
  "axelar-message-primitives",
@@ -2463,7 +2465,7 @@ dependencies = [
 [[package]]
 name = "governance-gmp"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/solana-axelar.git?branch=axelar-executable-updates#4e84c102a40320d1becdbe8f992e2e312b0b7170"
+source = "git+https://github.com/eigerco/solana-axelar.git?branch=main#7371554bb29d00a285f3df1ad17101251f00094a"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -3080,7 +3082,7 @@ dependencies = [
 [[package]]
 name = "interchain-token-transfer-gmp"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/solana-axelar.git?branch=axelar-executable-updates#4e84c102a40320d1becdbe8f992e2e312b0b7170"
+source = "git+https://github.com/eigerco/solana-axelar.git?branch=main#7371554bb29d00a285f3df1ad17101251f00094a"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -3135,7 +3137,7 @@ checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 [[package]]
 name = "its-instruction-builder"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/solana-axelar.git?branch=axelar-executable-updates#4e84c102a40320d1becdbe8f992e2e312b0b7170"
+source = "git+https://github.com/eigerco/solana-axelar.git?branch=main#7371554bb29d00a285f3df1ad17101251f00094a"
 dependencies = [
  "async-recursion",
  "axelar-executable",
@@ -4146,7 +4148,7 @@ dependencies = [
 [[package]]
 name = "program-utils"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/solana-axelar.git?branch=axelar-executable-updates#4e84c102a40320d1becdbe8f992e2e312b0b7170"
+source = "git+https://github.com/eigerco/solana-axelar.git?branch=main#7371554bb29d00a285f3df1ad17101251f00094a"
 dependencies = [
  "borsh 1.5.3",
  "bytemuck",
@@ -4843,7 +4845,7 @@ dependencies = [
 [[package]]
 name = "role-management"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/solana-axelar.git?branch=axelar-executable-updates#4e84c102a40320d1becdbe8f992e2e312b0b7170"
+source = "git+https://github.com/eigerco/solana-axelar.git?branch=main#7371554bb29d00a285f3df1ad17101251f00094a"
 dependencies = [
  "bincode",
  "bitflags 2.6.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,14 +80,14 @@ relayer-amplifier-state = { git = "https://github.com/eigerco/axelar-relayer-cor
 core-common-serde-utils = { git = "https://github.com/eigerco/axelar-relayer-core.git", package = "common-serde-utils", branch = "main" }
 
 # Solana Gateway
-axelar-solana-gateway = { git = "https://github.com/eigerco/solana-axelar.git", branch = "axelar-executable-updates", features = ["no-entrypoint"] }
-axelar-solana-its = { git = "https://github.com/eigerco/solana-axelar.git", branch = "axelar-executable-updates", features = ["no-entrypoint"] }
-axelar-solana-governance = { git = "https://github.com/eigerco/solana-axelar.git", branch = "axelar-executable-updates", features = ["no-entrypoint"] }
-gateway-event-stack = { git = "https://github.com/eigerco/solana-axelar.git", branch = "axelar-executable-updates" }
-axelar-solana-encoding = { git = "https://github.com/eigerco/solana-axelar.git", branch = "axelar-executable-updates" }
-axelar-message-primitives = { git = "https://github.com/eigerco/solana-axelar.git", branch = "axelar-executable-updates" }
-axelar-executable = { git = "https://github.com/eigerco/solana-axelar.git", branch = "axelar-executable-updates" }
-its-instruction-builder = { git = "https://github.com/eigerco/solana-axelar.git", branch = "axelar-executable-updates" }
+axelar-solana-gateway = { git = "https://github.com/eigerco/solana-axelar.git", branch = "main", features = ["no-entrypoint"] }
+axelar-solana-its = { git = "https://github.com/eigerco/solana-axelar.git", branch = "main", features = ["no-entrypoint"] }
+axelar-solana-governance = { git = "https://github.com/eigerco/solana-axelar.git", branch = "main", features = ["no-entrypoint"] }
+gateway-event-stack = { git = "https://github.com/eigerco/solana-axelar.git", branch = "main" }
+axelar-solana-encoding = { git = "https://github.com/eigerco/solana-axelar.git", branch = "main" }
+axelar-message-primitives = { git = "https://github.com/eigerco/solana-axelar.git", branch = "main" }
+axelar-executable = { git = "https://github.com/eigerco/solana-axelar.git", branch = "main" }
+its-instruction-builder = { git = "https://github.com/eigerco/solana-axelar.git", branch = "main" }
 
 # CLI
 clap = { version = "4", features = ["derive"] }

--- a/crates/solana-gateway-task-processor/src/component/message_payload.rs
+++ b/crates/solana-gateway-task-processor/src/component/message_payload.rs
@@ -19,7 +19,7 @@ use solana_sdk::signature::{Keypair, Signature};
 use solana_sdk::signer::Signer as _;
 use solana_sdk::transaction::Transaction;
 
-use super::send_transaction;
+use super::send_gateway_tx;
 
 /// Maximum number of bytes we can pack into each `GatewayInstruction::WriteMessagePayload`
 /// instruction.
@@ -130,7 +130,7 @@ async fn initialize(
             .context("Unexpected u64 overflow in buffer size")?,
     )
     .context("failed to construct an instruction to initialize the message payload pda")?;
-    send_transaction(solana_rpc_client, keypair, ix)
+    send_gateway_tx(solana_rpc_client, keypair, ix)
         .await
         .context("faled to initialize the message payload pda")?;
     Ok(())
@@ -173,7 +173,7 @@ async fn write(
         )
         .context("failed to construct an instruction to write to the message payload pda")?;
         futures.push(async move {
-            let tx = send_transaction(solana_rpc_client, keypair, ix).await;
+            let tx = send_gateway_tx(solana_rpc_client, keypair, ix).await;
             (offset, tx)
         });
     }
@@ -198,7 +198,7 @@ async fn commit(
         command_id,
     )
     .context("failed to construct an instruction to commit the message payload pda")?;
-    send_transaction(solana_rpc_client, keypair, ix)
+    send_gateway_tx(solana_rpc_client, keypair, ix)
         .await
         .context("failed to commit the message payload pda")?;
     Ok(())
@@ -218,7 +218,7 @@ pub(crate) async fn close(
         msg_command_id,
     )
     .context("failed to construct an instruction to close the message payload pda")?;
-    send_transaction(solana_rpc_client, keypair, ix)
+    send_gateway_tx(solana_rpc_client, keypair, ix)
         .await
         .context("failed to close the message payload pda")?;
     Ok(())


### PR DESCRIPTION
**Describe the changes**

This way we can ignore the error in case the account has already been initialized and/or in case the message has already been committed.

Also, added check to avoid uploading the message and calling the destination program in case the `IncomingMessage` has already been executed.

**Related Issue(s)**

Closes #12