### PR TITLE
fix: enalbe sync operations for mmap

### DIFF
--- a/crates/file-based-storage/src/lib.rs
+++ b/crates/file-based-storage/src/lib.rs
@@ -63,7 +63,7 @@ impl MemmapState {
         // SAFETY:
         // we ensured that the size is large enough
         let mmap = unsafe { MmapMut::map_mut(&file)? };
-        mmap.flush_async()?;
+        mmap.flush()?;
 
         Ok(Self {
             mmap: Arc::new(Mutex::new(mmap)),
@@ -100,7 +100,7 @@ impl MemmapState {
         let raw_u128 = task_item_id.0.as_u128();
         let data = bytemuck::from_bytes_mut::<InternalState>(&mut mmap[..]);
         field_mutator(data, raw_u128);
-        mmap.flush_async()?;
+        mmap.flush()?;
         drop(mmap);
         Ok(())
     }


### PR DESCRIPTION
**Describe the changes**

The internal state was configured for doing async flushes. Now we are using
the sync api for better guarantees.

**Related Issue(s)**
https://github.com/eigerco/axelar-solana-relayer/issues/20

**Checklist**

- [ ] Tests have been added/updated for the changes.
- [ ] Documentation has been updated for the changes (if applicable).
- [x] The code follows Rust's style guidelines.

**Additional Context**
Add any other context about the pull request here.
