### PR TITLE
fix: update dependencies to match latest updates in init gas config ix

### DIFF
--- a/.github/actions/setup-repo/action.yaml
+++ b/.github/actions/setup-repo/action.yaml
@@ -4,7 +4,7 @@ inputs:
   toolchain:
     description: "An example input parameter"
     required: false
-    default: "nightly-2024-09-24"
+    default: "nightly-2025-03-01"
 
 runs:
   using: "composite"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -709,7 +709,7 @@ dependencies = [
 [[package]]
 name = "axelar-executable"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/solana-axelar.git?rev=d89b0f6#d89b0f60c3a09b6de897bcab6c99c32b4c3c1078"
+source = "git+https://github.com/eigerco/solana-axelar.git?rev=f6c83f4#f6c83f41e8f9be2a912270e605ab10fe02ceeee6"
 dependencies = [
  "alloy-sol-types",
  "axelar-solana-encoding",
@@ -724,7 +724,7 @@ dependencies = [
 [[package]]
 name = "axelar-message-primitives"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/solana-axelar.git?rev=d89b0f6#d89b0f60c3a09b6de897bcab6c99c32b4c3c1078"
+source = "git+https://github.com/eigerco/solana-axelar.git?rev=f6c83f4#f6c83f41e8f9be2a912270e605ab10fe02ceeee6"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -740,7 +740,7 @@ dependencies = [
 [[package]]
 name = "axelar-solana-encoding"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/solana-axelar.git?rev=d89b0f6#d89b0f60c3a09b6de897bcab6c99c32b4c3c1078"
+source = "git+https://github.com/eigerco/solana-axelar.git?rev=f6c83f4#f6c83f41e8f9be2a912270e605ab10fe02ceeee6"
 dependencies = [
  "arrayref",
  "borsh 1.5.5",
@@ -757,7 +757,7 @@ dependencies = [
 [[package]]
 name = "axelar-solana-gas-service"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/solana-axelar.git?rev=d89b0f6#d89b0f60c3a09b6de897bcab6c99c32b4c3c1078"
+source = "git+https://github.com/eigerco/solana-axelar.git?rev=f6c83f4#f6c83f41e8f9be2a912270e605ab10fe02ceeee6"
 dependencies = [
  "borsh 1.5.5",
  "bytemuck",
@@ -771,7 +771,7 @@ dependencies = [
 [[package]]
 name = "axelar-solana-gateway"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/solana-axelar.git?rev=d89b0f6#d89b0f60c3a09b6de897bcab6c99c32b4c3c1078"
+source = "git+https://github.com/eigerco/solana-axelar.git?rev=f6c83f4#f6c83f41e8f9be2a912270e605ab10fe02ceeee6"
 dependencies = [
  "axelar-message-primitives",
  "axelar-solana-encoding",
@@ -794,7 +794,7 @@ dependencies = [
 [[package]]
 name = "axelar-solana-gateway-test-fixtures"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/solana-axelar.git?rev=d89b0f6#d89b0f60c3a09b6de897bcab6c99c32b4c3c1078"
+source = "git+https://github.com/eigerco/solana-axelar.git?rev=f6c83f4#f6c83f41e8f9be2a912270e605ab10fe02ceeee6"
 dependencies = [
  "axelar-executable",
  "axelar-solana-encoding",
@@ -820,7 +820,7 @@ dependencies = [
 [[package]]
 name = "axelar-solana-governance"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/solana-axelar.git?rev=d89b0f6#d89b0f60c3a09b6de897bcab6c99c32b4c3c1078"
+source = "git+https://github.com/eigerco/solana-axelar.git?rev=f6c83f4#f6c83f41e8f9be2a912270e605ab10fe02ceeee6"
 dependencies = [
  "alloy-sol-types",
  "axelar-executable",
@@ -837,7 +837,7 @@ dependencies = [
 [[package]]
 name = "axelar-solana-its"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/solana-axelar.git?rev=d89b0f6#d89b0f60c3a09b6de897bcab6c99c32b4c3c1078"
+source = "git+https://github.com/eigerco/solana-axelar.git?rev=f6c83f4#f6c83f41e8f9be2a912270e605ab10fe02ceeee6"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -863,7 +863,7 @@ dependencies = [
 [[package]]
 name = "axelar-solana-memo-program"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/solana-axelar.git?rev=d89b0f6#d89b0f60c3a09b6de897bcab6c99c32b4c3c1078"
+source = "git+https://github.com/eigerco/solana-axelar.git?rev=f6c83f4#f6c83f41e8f9be2a912270e605ab10fe02ceeee6"
 dependencies = [
  "axelar-executable",
  "axelar-solana-encoding",
@@ -2680,7 +2680,7 @@ dependencies = [
 [[package]]
 name = "gateway-event-stack"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/solana-axelar.git?rev=d89b0f6#d89b0f60c3a09b6de897bcab6c99c32b4c3c1078"
+source = "git+https://github.com/eigerco/solana-axelar.git?rev=f6c83f4#f6c83f41e8f9be2a912270e605ab10fe02ceeee6"
 dependencies = [
  "axelar-solana-gas-service",
  "axelar-solana-gateway",
@@ -2834,7 +2834,7 @@ dependencies = [
 [[package]]
 name = "governance-gmp"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/solana-axelar.git?rev=d89b0f6#d89b0f60c3a09b6de897bcab6c99c32b4c3c1078"
+source = "git+https://github.com/eigerco/solana-axelar.git?rev=f6c83f4#f6c83f41e8f9be2a912270e605ab10fe02ceeee6"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -3597,7 +3597,7 @@ dependencies = [
 [[package]]
 name = "interchain-token-transfer-gmp"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/solana-axelar.git?rev=d89b0f6#d89b0f60c3a09b6de897bcab6c99c32b4c3c1078"
+source = "git+https://github.com/eigerco/solana-axelar.git?rev=f6c83f4#f6c83f41e8f9be2a912270e605ab10fe02ceeee6"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -3652,7 +3652,7 @@ checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 [[package]]
 name = "its-instruction-builder"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/solana-axelar.git?rev=d89b0f6#d89b0f60c3a09b6de897bcab6c99c32b4c3c1078"
+source = "git+https://github.com/eigerco/solana-axelar.git?rev=f6c83f4#f6c83f41e8f9be2a912270e605ab10fe02ceeee6"
 dependencies = [
  "async-recursion",
  "axelar-executable",
@@ -5185,7 +5185,7 @@ dependencies = [
 [[package]]
 name = "program-utils"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/solana-axelar.git?rev=d89b0f6#d89b0f60c3a09b6de897bcab6c99c32b4c3c1078"
+source = "git+https://github.com/eigerco/solana-axelar.git?rev=f6c83f4#f6c83f41e8f9be2a912270e605ab10fe02ceeee6"
 dependencies = [
  "borsh 1.5.5",
  "bytemuck",
@@ -6014,7 +6014,7 @@ dependencies = [
 [[package]]
 name = "role-management"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/solana-axelar.git?rev=d89b0f6#d89b0f60c3a09b6de897bcab6c99c32b4c3c1078"
+source = "git+https://github.com/eigerco/solana-axelar.git?rev=f6c83f4#f6c83f41e8f9be2a912270e605ab10fe02ceeee6"
 dependencies = [
  "bincode",
  "bitflags 2.8.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,18 +82,18 @@ relayer-amplifier-state = { git = "https://github.com/eigerco/axelar-relayer-cor
 core-common-serde-utils = { git = "https://github.com/eigerco/axelar-relayer-core.git", package = "common-serde-utils", rev = "5c909d2" }
 
 # Solana Gateway
-axelar-solana-gateway = { git = "https://github.com/eigerco/solana-axelar.git", rev = "d89b0f6", features = ["no-entrypoint"] }
-axelar-solana-its = { git = "https://github.com/eigerco/solana-axelar.git", rev = "d89b0f6", features = ["no-entrypoint"] }
-axelar-solana-governance = { git = "https://github.com/eigerco/solana-axelar.git", rev = "d89b0f6", features = ["no-entrypoint"] }
-gateway-event-stack = { git = "https://github.com/eigerco/solana-axelar.git", rev = "d89b0f6" }
-axelar-solana-encoding = { git = "https://github.com/eigerco/solana-axelar.git", rev = "d89b0f6" }
-axelar-solana-gas-service = { git = "https://github.com/eigerco/solana-axelar.git", rev = "d89b0f6", features = ["no-entrypoint"] }
-axelar-solana-memo-program = { git = "https://github.com/eigerco/solana-axelar.git", rev = "d89b0f6", features = ["no-entrypoint"] }
-axelar-solana-gateway-test-fixtures = { git = "https://github.com/eigerco/solana-axelar.git", rev = "d89b0f6" }
-axelar-message-primitives = { git = "https://github.com/eigerco/solana-axelar.git", rev = "d89b0f6" }
-axelar-executable = { git = "https://github.com/eigerco/solana-axelar.git", rev = "d89b0f6" }
-its-instruction-builder = { git = "https://github.com/eigerco/solana-axelar.git", rev = "d89b0f6" }
-interchain-token-transfer-gmp = { git = "https://github.com/eigerco/solana-axelar.git", rev = "d89b0f6" }
+axelar-solana-gateway = { git = "https://github.com/eigerco/solana-axelar.git", rev = "f6c83f4", features = ["no-entrypoint"] }
+axelar-solana-its = { git = "https://github.com/eigerco/solana-axelar.git", rev = "f6c83f4", features = ["no-entrypoint"] }
+axelar-solana-governance = { git = "https://github.com/eigerco/solana-axelar.git", rev = "f6c83f4", features = ["no-entrypoint"] }
+gateway-event-stack = { git = "https://github.com/eigerco/solana-axelar.git", rev = "f6c83f4" }
+axelar-solana-encoding = { git = "https://github.com/eigerco/solana-axelar.git", rev = "f6c83f4" }
+axelar-solana-gas-service = { git = "https://github.com/eigerco/solana-axelar.git", rev = "f6c83f4", features = ["no-entrypoint"] }
+axelar-solana-memo-program = { git = "https://github.com/eigerco/solana-axelar.git", rev = "f6c83f4", features = ["no-entrypoint"] }
+axelar-solana-gateway-test-fixtures = { git = "https://github.com/eigerco/solana-axelar.git", rev = "f6c83f4" }
+axelar-message-primitives = { git = "https://github.com/eigerco/solana-axelar.git", rev = "f6c83f4" }
+axelar-executable = { git = "https://github.com/eigerco/solana-axelar.git", rev = "f6c83f4" }
+its-instruction-builder = { git = "https://github.com/eigerco/solana-axelar.git", rev = "f6c83f4" }
+interchain-token-transfer-gmp = { git = "https://github.com/eigerco/solana-axelar.git", rev = "f6c83f4" }
 
 # CLI
 clap = { version = "4", features = ["derive"] }

--- a/crates/solana-event-forwarder/src/component.rs
+++ b/crates/solana-event-forwarder/src/component.rs
@@ -1404,7 +1404,7 @@ mod tests {
     ) {
         // init gas config
         let gas_service_upgr_auth = fixture.payer.insecure_clone();
-        let gas_config = fixture.setup_default_gas_config(gas_service_upgr_auth);
+        let gas_config = fixture.setup_default_gas_config(gas_service_upgr_auth.insecure_clone());
         let ix = axelar_solana_gas_service::instructions::init_config(
             &axelar_solana_gas_service::ID,
             &fixture.payer.pubkey(),
@@ -1413,8 +1413,12 @@ mod tests {
             gas_config.salt,
         )
         .unwrap();
+        let payer = fixture.payer.insecure_clone();
         let gas_init_sig = *fixture
-            .send_tx_with_signatures(&[ix])
+            .send_tx_with_custom_signers_and_signature(
+                &[ix],
+                &[payer, gas_config.config_authority.insecure_clone()],
+            )
             .await
             .unwrap()
             .0

--- a/crates/solana-listener/src/component/signature_batch_scanner.rs
+++ b/crates/solana-listener/src/component/signature_batch_scanner.rs
@@ -584,8 +584,12 @@ pub(crate) mod test {
             gas_config.salt,
         )
         .unwrap();
+        let payer = fixture.payer.insecure_clone();
         let gas_init_sig = *fixture
-            .send_tx_with_signatures(&[ix])
+            .send_tx_with_custom_signers_and_signature(
+                &[ix],
+                &[payer, gas_config.config_authority.insecure_clone()],
+            )
             .await
             .unwrap()
             .0

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -34,7 +34,7 @@ fn main() -> eyre::Result<()> {
     match args.command {
         Commands::Deny { args } => {
             println!("cargo deny");
-            cmd!(sh, "cargo install cargo-deny").run()?;
+            cmd!(sh, "cargo +nightly install cargo-deny").run()?;
             cmd!(sh, "cargo deny check {args...}").run()?;
         }
         Commands::Test { args, coverage } => {
@@ -105,7 +105,7 @@ fn main() -> eyre::Result<()> {
         }
         Commands::UnusedDeps => {
             println!("unused deps");
-            cmd!(sh, "cargo install cargo-machete").run()?;
+            cmd!(sh, "cargo +nightly install cargo-machete").run()?;
             cmd!(sh, "cargo-machete").run()?;
         }
     }


### PR DESCRIPTION
**Describe the changes**

Ensure now the relayer tests uses the authority as signer for matching the gas service implementation.

**Related Issue(s)**
https://github.com/eigerco/solana-axelar-internal/issues/655