### PR TITLE
fix(task-processor): change event on simulation error

### DIFF
--- a/crates/gateway-gas-computation/src/lib.rs
+++ b/crates/gateway-gas-computation/src/lib.rs
@@ -188,7 +188,13 @@ async fn cost_of_signature_verification(
     Ok(verify_signatures_costs)
 }
 
-async fn cost_of_payload_uploading(
+/// Computes the cost of uploading the message payload.
+///
+/// # Errors
+///
+/// - if no transactions are found.
+/// - if no logs are found for a transaction.
+pub async fn cost_of_payload_uploading(
     rpc: &RpcClient,
     commitment: CommitmentConfig,
     message_payload_pda: Pubkey,


### PR DESCRIPTION
**Describe the changes**

When a simulation error happens in the execute_task flow, we might have already uploaded the payload to solana and thus incurred costs. As costs can only be passed in the MESSAGE_EXECUTED event, we need to use it to report back to Axelar. This is a temporary fix until the Amplifier API is updated to accept all txs in the flow, when this happens, we'll also need to keep track of all the transactions that went beyond the simulation step.
