### PR TITLE
feat: allow enable/disable third party contract calls from env var

### DIFF
--- a/crates/solana-axelar-relayer/src/main.rs
+++ b/crates/solana-axelar-relayer/src/main.rs
@@ -38,7 +38,7 @@ async fn main() {
     let (amplifier_component, amplifier_client, amplifier_task_receiver) =
         Amplifier::new(config.amplifier_component, file_based_storage.clone());
     let gateway_task_processor = solana_gateway_task_processor::SolanaTxPusher::new(
-        config.solana_gateway_task_processor,
+        Arc::new(config.solana_gateway_task_processor),
         name_on_amplifier.clone(),
         Arc::clone(&rpc_client),
         amplifier_task_receiver,
@@ -227,6 +227,7 @@ mod tests {
                 gas_service_config_pda,
                 signing_keypair: signing_keypair_as_str,
                 commitment: CommitmentConfig::finalized(),
+                allow_third_party_contract_calls: false,
             },
             solana_rpc: retrying_solana_http_sender::Config {
                 max_concurrent_rpc_requests,

--- a/crates/solana-gateway-task-processor/src/config.rs
+++ b/crates/solana-gateway-task-processor/src/config.rs
@@ -51,6 +51,19 @@ pub struct Config {
         default_value = "finalized"
     )]
     pub commitment: CommitmentConfig,
+
+    /// Wether to allow third party contract calls. Currently calling user defined programs
+    /// is not allowed for testnet and mainnet environments.
+    /// Check the context on this issue for more details: <https://github.com/eigerco/axelar-solana-relayer/issues/37>
+    /// This is a temporary measure.
+    #[builder(default = config_defaults::allow_third_party_contract_calls())]
+    #[serde(default = "config_defaults::allow_third_party_contract_calls")]
+    #[arg(
+        value_name = "ALLOW_THIRD_PARTY_CONTRACT_CALLS",
+        env = "ALLOW_THIRD_PARTY_CONTRACT_CALLS",
+        default_value = config_defaults::gas_service_program_address().to_string()
+    )]
+    pub allow_third_party_contract_calls: bool,
 }
 
 impl Config {
@@ -70,6 +83,9 @@ pub(crate) mod config_defaults {
 
     pub(crate) const fn gas_service_program_address() -> Pubkey {
         axelar_solana_gas_service::id()
+    }
+    pub(crate) const fn allow_third_party_contract_calls() -> bool {
+        false
     }
 }
 


### PR DESCRIPTION
Closes #64 

* We cannot trust in rpc client url anymore to determine environment, as we will be using third party provider Solana node RPC
* Adds `allow_third_party_contract_calls` config option.